### PR TITLE
Add linux ci and missing feature

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,7 @@ jobs:
           [
             { os: "macos-latest", toolchain: "1.59.0" },
             { os: "windows-latest", toolchain: "stable" },
+            { os: "ubuntu-latest", toolchain: "stable" },
           ]
     runs-on: ${{ matrix.os-and-toolchain.os }}
     steps:

--- a/pkcs11-sys/pkcs11.h
+++ b/pkcs11-sys/pkcs11.h
@@ -36,7 +36,7 @@
 #if defined(_WIN32) || defined(CRYPTOKI_FORCE_WIN32)
 #endif
 
-#include "../third_party/pkcs11/pkcs11.h"
+#include "third_party/pkcs11/pkcs11.h"
 
 #if defined(_WIN32) || defined(CRYPTOKI_FORCE_WIN32)
 #pragma pack(pop, cryptoki)

--- a/pkcs11-sys/third_party
+++ b/pkcs11-sys/third_party
@@ -1,0 +1,1 @@
+../third_party

--- a/pkcs11/Cargo.toml
+++ b/pkcs11/Cargo.toml
@@ -12,7 +12,10 @@ license = "Apache-2.0"
 
 [dependencies]
 once_cell = "1.16.0"
-p256 = { version = "0.12.0-pre.0", default-features = false, features = ["arithmetic"] }
+p256 = { version = "0.12.0-pre.0", default-features = false, features = [
+    "arithmetic",
+    "pkcs8",
+] }
 pkcs1 = { version = "0.4.1", default-features = false }
 pkcs11-sys = { path = "../pkcs11-sys" }
 pkcs11-traits = { version = "0.1.0", path = "../pkcs11-traits" }


### PR DESCRIPTION
Also symlink third_party/pkcs11 in pkcs11-sys crate.

This copies header files into the crate when it is vendored so they are present for
bindgen.