### PR TITLE
Replace abandoned GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,11 +39,9 @@ jobs:
     runs-on: ${{ matrix.os-and-toolchain.os }}
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+      - uses: dtolnay/rust-toolchain@e645b0cf01249a964ec099494d38d2da0f0b349f
         with:
           toolchain: ${{ matrix.os-and-toolchain.toolchain }}
-          profile: minimal
-          override: true
       - name: Build
         run: cargo build --verbose
 
@@ -56,11 +54,7 @@ jobs:
   clippy:
     name: clippy
     runs-on: macos-latest
-    permissions:
-      checks: write
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v1.2.0
       - run: rustup component add clippy
-      - uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d # v1.0.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions-rs-plus/clippy-check@6f0b6d890ba378af1e3fa09f796f6e01dad7fa9b


### PR DESCRIPTION
The actions-rs actions are unmaintained, see actions-rs/clippy-check#162 and actions-rs/clippy-check#162 for details. 

- [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) appears to be a well supported replacement for [actions-rs/toolchain](https://github.com/actions-rs/toolchain).
- [actions-rs-plus/clippy-check](https://github.com/actions-rs-plus/clippy-check) is a modernized fork of [actions-rs/clippy-check](https://github.com/actions-rs/clippy-check), however the maintenance status is less clear and might need to be replaced again in the future.