### PR TITLE
Run Clippy without a workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,8 +53,11 @@ jobs:
 
   clippy:
     name: clippy
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v1.2.0
-      - run: rustup component add clippy
-      - uses: actions-rs-plus/clippy-check@02fcef91666c1f7a6d82c05da66378898a34d79f
+      - uses: dtolnay/rust-toolchain@ce8f65846d7180d2ce63b1e74483d981800b9e22
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+      - run: cargo clippy


### PR DESCRIPTION
[actions-rs/clippy-check](https://github.com/actions-rs/clippy-check) is unmaintained and was replaced with [actions-rs-plus/clippy-check](https://github.com/actions-rs-plus/clippy-check) in #27. [actions-rs-plus/clippy-check](https://github.com/actions-rs-plus/clippy-check) _also_ appears to be unmaintained per actions-rs-plus/clippy-check#105, yet has a lot of version churn due to the repo having an automated Dependabot PR approval workflow.

So I'm just giving up on having a Clippy workflow for now. Instead just run Clippy without annotations being posted to the PR.