### PR TITLE
Implement RSA PSS padding

### DIFF
--- a/native-pkcs11-keychain/src/macos/mod.rs
+++ b/native-pkcs11-keychain/src/macos/mod.rs
@@ -16,6 +16,7 @@ use std::fmt::Debug;
 
 pub use backend::KeychainBackend;
 use core_foundation::error::CFError;
+use native_pkcs11_traits::SignatureAlgorithm;
 use thiserror::Error;
 use tracing_error::SpanTrace;
 
@@ -79,6 +80,9 @@ pub enum ErrorKind {
 
     #[error("{0}")]
     Pkcs1(#[from] rsa::pkcs1::Error),
+
+    #[error("{0:?}")]
+    UnsupportedSignatureAlgorithm(SignatureAlgorithm),
 }
 
 impl From<CFError> for ErrorKind {

--- a/native-pkcs11-traits/src/lib.rs
+++ b/native-pkcs11-traits/src/lib.rs
@@ -40,7 +40,28 @@ pub fn backend() -> &'static dyn Backend {
     BACKEND.as_ref()
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum DigestType {
+    Sha1,
+    Sha224,
+    Sha256,
+    Sha384,
+    Sha512,
+}
+
+impl DigestType {
+    pub fn digest_len(&self) -> usize {
+        match self {
+            DigestType::Sha1 => 20,
+            DigestType::Sha224 => 28,
+            DigestType::Sha256 => 32,
+            DigestType::Sha384 => 48,
+            DigestType::Sha512 => 64,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub enum SignatureAlgorithm {
     Ecdsa,
     RsaRaw,
@@ -49,6 +70,11 @@ pub enum SignatureAlgorithm {
     RsaPkcs1v15Sha384,
     RsaPkcs1v15Sha256,
     RsaPkcs1v15Sha512,
+    RsaPss {
+        digest: DigestType,
+        mask_generation_function: DigestType,
+        salt_length: u64,
+    },
 }
 
 pub trait PrivateKey: Send + Sync {


### PR DESCRIPTION
- Parse PSS parameters
- Remove EnumIter from Mechanism since the PSS variant has integer parameters

Tested with

```bash
$ p11tool --sign-params='RSA-PSS' --test-sign 'pkcs11:token=Keychain;id=<redacted>'
Signing using RSA-PSS-SHA256...
ok
Verifying against private key parameters... ok
```