### PR TITLE
Drop dependency on rsa crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc302fd9b18d66834a6f092d10ea85489c0ca8ad6b7304092135fab171d853cd"
+dependencies = [
+ "const-oid",
+]
+
+[[package]]
 name = "der_derive"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,7 +196,7 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12844141594ad74185a926d030f3b605f6a903b4e3fec351f3ea338ac5b7637e"
 dependencies = [
- "der",
+ "der 0.6.1",
  "elliptic-curve",
  "signature",
 ]
@@ -206,7 +215,7 @@ checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "der",
+ "der 0.6.1",
  "digest",
  "ff",
  "generic-array",
@@ -387,8 +396,8 @@ dependencies = [
  "native-pkcs11-windows",
  "once_cell",
  "p256",
+ "pkcs1 0.7.0",
  "pkcs11-sys",
- "rsa",
  "serial_test",
  "strum",
  "strum_macros",
@@ -574,10 +583,20 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
 dependencies = [
- "der",
+ "der 0.6.1",
  "pkcs8",
- "spki",
+ "spki 0.6.0",
  "zeroize",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aafe31c51bd5e2345ab4e6239edbee9a58da741ffe0f3d426a325d8bc9f463de"
+dependencies = [
+ "der 0.7.0",
+ "spki 0.7.0",
 ]
 
 [[package]]
@@ -593,8 +612,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -729,7 +748,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "pkcs1",
+ "pkcs1 0.4.1",
  "pkcs8",
  "rand_core",
  "signature",
@@ -762,7 +781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.6.1",
  "generic-array",
  "pkcs8",
  "subtle",
@@ -860,7 +879,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
+dependencies = [
+ "der 0.7.0",
 ]
 
 [[package]]
@@ -1146,9 +1174,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d224a125dec5adda27d0346b9cae9794830279c4f9c27e4ab0b6c408d54012"
 dependencies = [
  "const-oid",
- "der",
+ "der 0.6.1",
  "flagset",
- "spki",
+ "spki 0.6.0",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -11,10 +11,7 @@ unmaintained = "deny"
 unsound = "deny"
 yanked = "deny"
 notice = "deny"
-ignore = [
-    #TODO(bweeks): disambiguate our pkcs11 crate name.
-    "RUSTSEC-2022-0034",
-]
+ignore = []
 
 [licenses]
 allow = ["Apache-2.0", "BSD-3-Clause", "ISC", "MIT", "Unicode-DFS-2016"]
@@ -22,6 +19,11 @@ copyleft = "deny"
 
 [bans]
 multiple-versions = "deny"
+skip = [
+    { name = "der", version = "=0.6.1" },
+    { name = "pkcs1", version = "=0.4.1" },
+    { name = "spki", version = "=0.6.0" },
+]
 
 [sources]
 unknown-registry = "deny"

--- a/native-pkcs11-core/Cargo.toml
+++ b/native-pkcs11-core/Cargo.toml
@@ -15,8 +15,8 @@ p256 = { version = "0.12.0", default-features = false, features = [
     "arithmetic",
     "pkcs8",
 ] }
+pkcs1 = { version = "0.7.0", default-features = false }
 pkcs11-sys = { version = "0.2.0", path = "../pkcs11-sys" }
-rsa = { version = "0.8.1", default-features = false }
 strum = "0.24.1"
 strum_macros = "0.24.3"
 thiserror = "1.0.38"

--- a/native-pkcs11-core/src/object.rs
+++ b/native-pkcs11-core/src/object.rs
@@ -16,6 +16,7 @@ use std::{ffi::CString, fmt::Debug, sync::Arc};
 
 use native_pkcs11_traits::{backend, Certificate, CertificateExt, PrivateKey, PublicKey};
 use p256::pkcs8::AssociatedOid;
+use pkcs1::{der::Decode, RsaPrivateKey, RsaPublicKey};
 use pkcs11_sys::{
     CKC_X_509,
     CKK_EC,
@@ -26,7 +27,6 @@ use pkcs11_sys::{
     CKO_PUBLIC_KEY,
     CK_PROFILE_ID,
 };
-use rsa::pkcs1::{der::Decode, RsaPrivateKey, RsaPublicKey};
 use tracing::warn;
 
 use crate::attribute::{Attribute, AttributeType, Attributes};


### PR DESCRIPTION
Partially reverts "Use re-exported RustCrypto deps" to avoid taking a dependency on the rsa crate.