### PR TITLE
Add all keys to object_store, not just by certificate -> key lookup

### DIFF
--- a/native-pkcs11-keychain/src/macos/key.rs
+++ b/native-pkcs11-keychain/src/macos/key.rs
@@ -320,11 +320,11 @@ pub fn find_key2(class: KeyClass, label: &[u8]) -> Result<Option<SecKey>> {
 }
 
 #[instrument]
-pub fn find_all_private_keys() -> Result<Vec<SecKey>> {
+pub fn find_all_keys(key_class: KeyClass) -> Result<Vec<SecKey>> {
     let results = ItemSearchOptions::new()
         .load_refs(true)
         .class(ItemClass::key())
-        .key_class(KeyClass::private())
+        .key_class(key_class)
         .limit(Limit::All)
         .search();
 

--- a/native-pkcs11-traits/src/lib.rs
+++ b/native-pkcs11-traits/src/lib.rs
@@ -186,6 +186,8 @@ impl<T: Certificate + ?Sized> CertificateExt for T {}
 
 #[derive(Debug)]
 pub enum KeySearchOptions {
+    //  TODO(kcking): search keys by _both_ label and public key hash as that is how
+    //  they are de-duped and referenced.
     Label(String),
     PublicKeyHash(Digest),
 }
@@ -202,6 +204,7 @@ pub trait Backend: Send + Sync {
     fn find_private_key(&self, query: KeySearchOptions) -> Result<Option<Arc<dyn PrivateKey>>>;
     fn find_public_key(&self, query: KeySearchOptions) -> Result<Option<Box<dyn PublicKey>>>;
     fn find_all_private_keys(&self) -> Result<Vec<Arc<dyn PrivateKey>>>;
+    fn find_all_public_keys(&self) -> Result<Vec<Arc<dyn PublicKey>>>;
     fn generate_key(
         &self,
         algorithm: KeyAlgorithm,

--- a/native-pkcs11-windows/src/win/mod.rs
+++ b/native-pkcs11-windows/src/win/mod.rs
@@ -91,6 +91,12 @@ impl Backend for WindowsBackend {
         Ok(vec![])
     }
 
+    fn find_all_public_keys(
+        &self,
+    ) -> native_pkcs11_traits::Result<Vec<Arc<dyn native_pkcs11_traits::PublicKey>>> {
+        Ok(vec![])
+    }
+
     fn generate_key(
         &self,
         _algorithm: native_pkcs11_traits::KeyAlgorithm,


### PR DESCRIPTION
We currently add private keys to the object store based on looking up the key of a Certificate by public_key_hash. If there are mulitple private keys with the same key material, but different labels, this lookup will only return one of those keys, and it will have an arbitrary label.

This mismatch is causing the pkcs11 openssl engine to not be able to find the associated private key for a certificate. This commit adds all private and public keys to the object store to make sure we don't miss any.

In the future we may want to re-consider how we lookup keys, perhaps requiring both an (Optional) label _and_ a pubkey hash.