### PR TITLE
Drop support for sensitive key attributes

### DIFF
--- a/native-pkcs11-keychain/src/macos/key.rs
+++ b/native-pkcs11-keychain/src/macos/key.rs
@@ -121,13 +121,6 @@ impl PrivateKey for KeychainPrivateKey {
     }
 
     #[instrument]
-    fn to_der(&self) -> Option<Vec<u8>> {
-        self.sec_key
-            .external_representation()
-            .map(|data| data.bytes().to_vec())
-    }
-
-    #[instrument]
     fn sign(
         &self,
         algorithm: &native_pkcs11_traits::SignatureAlgorithm,

--- a/native-pkcs11-traits/src/lib.rs
+++ b/native-pkcs11-traits/src/lib.rs
@@ -80,8 +80,6 @@ pub enum SignatureAlgorithm {
 pub trait PrivateKey: Send + Sync {
     fn public_key_hash(&self) -> Vec<u8>;
     fn label(&self) -> String;
-    //  `None` if the key is not exportable.
-    fn to_der(&self) -> Option<Vec<u8>>;
     fn sign(&self, algorithm: &SignatureAlgorithm, data: &[u8]) -> Result<Vec<u8>>;
     fn delete(&self);
     fn algorithm(&self) -> KeyAlgorithm;


### PR DESCRIPTION
Also always set CKA_SENSITIVE, CKA_ALWAYS_SENSITIVE, and CKA_NEVER_EXTRACTABLE to true; CKA_EXTRACTABLE to false.