### PR TITLE
Release 0.2.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "native-pkcs11"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "native-pkcs11-core",
  "native-pkcs11-keychain",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-core"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "native-pkcs11-keychain",
  "native-pkcs11-traits",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-keychain"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "core-foundation",
  "native-pkcs11-traits",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-traits"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "once_cell",
  "rand",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-windows"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "native-pkcs11-traits",
  "windows",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs11-sys"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "bindgen",
 ]

--- a/native-pkcs11-core/Cargo.toml
+++ b/native-pkcs11-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-core"
-version = "0.2.7"
+version = "0.2.8"
 description = "Shared cross-platform PKCS#11 module logic for native-pkcs11."
 authors.workspace = true
 edition.workspace = true

--- a/native-pkcs11-keychain/Cargo.toml
+++ b/native-pkcs11-keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-keychain"
-version = "0.2.7"
+version = "0.2.8"
 description = "native-pkcs11 backend for macos keychain."
 authors.workspace = true
 edition.workspace = true

--- a/native-pkcs11-traits/Cargo.toml
+++ b/native-pkcs11-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-traits"
-version = "0.2.7"
+version = "0.2.8"
 description = "Traits for implementing and interactive with native-pkcs11 module backends."
 authors.workspace = true
 edition.workspace = true

--- a/native-pkcs11-windows/Cargo.toml
+++ b/native-pkcs11-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-windows"
-version = "0.2.7"
+version = "0.2.8"
 description = "[wip] native-pkcs11 backend for windows."
 authors.workspace = true
 edition.workspace = true

--- a/native-pkcs11/Cargo.toml
+++ b/native-pkcs11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11"
-version = "0.2.7"
+version = "0.2.8"
 description = "Cross-platform PKCS#11 module written in rust. Can be extended with custom credential backends."
 authors.workspace = true
 edition.workspace = true

--- a/pkcs11-sys/Cargo.toml
+++ b/pkcs11-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs11-sys"
-version = "0.2.7"
+version = "0.2.8"
 description = "Generated bindings for pkcs11.h. Useful for building PKCS#11 modules in rust."
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
native-pkcs11@0.2.8
native-pkcs11-core@0.2.8
native-pkcs11-keychain@0.2.8
native-pkcs11-traits@0.2.8
native-pkcs11-windows@0.2.8
pkcs11-sys@0.2.8

Generated by cargo-workspaces