### PR TITLE
Explicitly set Cargo resolver version in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "native-pkcs11",
     "native-pkcs11-core",

--- a/native-pkcs11/Cargo.toml
+++ b/native-pkcs11/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1.0.48"
 tracing = "0.1.37"
 tracing-error = "0.2.0"
 tracing-journald = "0.3"
-tracing-subscriber = "0.3.17"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [lib]
 crate-type = ["lib", "cdylib"]


### PR DESCRIPTION
```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

Context: https://github.com/rust-lang/cargo/issues/10112