### PR TITLE
Use compound of Label and PublicKeyHash as Id attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +475,7 @@ dependencies = [
 name = "native-pkcs11-core"
 version = "0.2.13"
 dependencies = [
+ "bincode",
  "native-pkcs11-keychain",
  "native-pkcs11-traits",
  "native-pkcs11-windows",
@@ -473,6 +483,7 @@ dependencies = [
  "p256",
  "pkcs1",
  "pkcs11-sys",
+ "serde",
  "serial_test",
  "strum",
  "strum_macros",
@@ -872,6 +883,26 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/native-pkcs11-core/Cargo.toml
+++ b/native-pkcs11-core/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+bincode = "1.3.3"
 native-pkcs11-traits = { version = "0.2.0", path = "../native-pkcs11-traits" }
 once_cell = "1.18.0"
 p256 = { version = "0.13.2", default-features = false, features = [
@@ -18,6 +19,7 @@ p256 = { version = "0.13.2", default-features = false, features = [
 ] }
 pkcs1 = { version = "0.7.5", default-features = false }
 pkcs11-sys = { version = "0.2.0", path = "../pkcs11-sys" }
+serde = { version = "1.0.188", features = ["derive"] }
 strum = "0.25.0"
 strum_macros = "0.25.2"
 thiserror = "1.0.48"

--- a/native-pkcs11-core/src/compoundid.rs
+++ b/native-pkcs11-core/src/compoundid.rs
@@ -1,0 +1,38 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bincode::Options;
+
+use crate::Result;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Id {
+    pub label: Option<String>,
+    pub public_key_hash: Vec<u8>,
+}
+
+fn bincode_opts() -> impl bincode::Options {
+    bincode::options()
+        .with_limit(2048)
+        .reject_trailing_bytes()
+        .with_fixint_encoding()
+}
+
+pub fn encode(id: &Id) -> Result<Vec<u8>> {
+    Ok(bincode_opts().serialize(id)?)
+}
+
+pub fn decode(data: &[u8]) -> Result<Id> {
+    Ok(bincode_opts().deserialize(data)?)
+}

--- a/native-pkcs11-core/src/lib.rs
+++ b/native-pkcs11-core/src/lib.rs
@@ -17,6 +17,7 @@ use pkcs11_sys::*;
 use thiserror::Error;
 
 pub mod attribute;
+pub mod compoundid;
 pub mod mechanism;
 pub mod object;
 
@@ -104,6 +105,9 @@ pub enum Error {
     Backend(#[from] Box<dyn std::error::Error>),
 
     #[error("{0}")]
+    Bincode(#[from] Box<bincode::ErrorKind>),
+
+    #[error("{0}")]
     Todo(String),
 }
 
@@ -130,6 +134,7 @@ impl From<Error> for CK_RV {
             Error::TokenWriteProtected => CKR_TOKEN_WRITE_PROTECTED,
 
             Error::Backend(_)
+            | Error::Bincode(_)
             | Error::FromUtf8(_)
             | Error::FromVecWithNul(_)
             | Error::NullPtr

--- a/native-pkcs11-core/src/object.rs
+++ b/native-pkcs11-core/src/object.rs
@@ -86,7 +86,13 @@ impl Object {
                 )),
                 AttributeType::CertificateType => Some(Attribute::CertificateType(CKC_X_509)),
                 AttributeType::Class => Some(Attribute::Class(CKO_CERTIFICATE)),
-                AttributeType::Id => Some(Attribute::Id(cert.public_key().public_key_hash())),
+                AttributeType::Id => Some(Attribute::Id(
+                    crate::compoundid::encode(&crate::compoundid::Id {
+                        label: Some(cert.label()),
+                        public_key_hash: cert.public_key().public_key_hash(),
+                    })
+                    .ok()?,
+                )),
                 AttributeType::Issuer => Some(Attribute::Issuer(cert.issuer())),
                 AttributeType::Label => Some(Attribute::Label(cert.label())),
                 AttributeType::Token => Some(Attribute::Token(true)),
@@ -108,7 +114,13 @@ impl Object {
                     Some(Attribute::EcParams(p256::NistP256::OID.to_der().ok()?))
                 }
                 AttributeType::Extractable => Some(Attribute::Extractable(false)),
-                AttributeType::Id => Some(Attribute::Id(private_key.public_key_hash())),
+                AttributeType::Id => Some(Attribute::Id(
+                    crate::compoundid::encode(&crate::compoundid::Id {
+                        label: Some(private_key.label()),
+                        public_key_hash: private_key.public_key_hash(),
+                    })
+                    .ok()?,
+                )),
                 AttributeType::KeyType => Some(Attribute::KeyType(match private_key.algorithm() {
                     native_pkcs11_traits::KeyAlgorithm::Rsa => CKK_RSA,
                     native_pkcs11_traits::KeyAlgorithm::Ecc => CKK_EC,
@@ -178,7 +190,13 @@ impl Object {
                     native_pkcs11_traits::KeyAlgorithm::Rsa => CKK_RSA,
                     native_pkcs11_traits::KeyAlgorithm::Ecc => CKK_EC,
                 })),
-                AttributeType::Id => Some(Attribute::Id(pk.public_key_hash())),
+                AttributeType::Id => Some(Attribute::Id(
+                    crate::compoundid::encode(&crate::compoundid::Id {
+                        label: Some(pk.label()),
+                        public_key_hash: pk.public_key_hash(),
+                    })
+                    .ok()?,
+                )),
                 AttributeType::EcPoint => {
                     if pk.algorithm() != KeyAlgorithm::Ecc {
                         return None;

--- a/native-pkcs11-keychain/src/bin/create_selfsigned.rs
+++ b/native-pkcs11-keychain/src/bin/create_selfsigned.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), native_pkcs11_keychain::Error> {
     let cert_der = self_signed_certificate(key::Algorithm::RSA, &key)?;
 
     let key_der = key.external_representation().unwrap().to_vec();
-    std::fs::write("/tmp/importkey.der", &key_der).unwrap();
+    std::fs::write("/tmp/importkey.der", key_der).unwrap();
 
     //  convert cert to PEM
     let mut child = std::process::Command::new("openssl")

--- a/native-pkcs11/src/object_store.rs
+++ b/native-pkcs11/src/object_store.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 
 use native_pkcs11_core::{
     attribute::{Attribute, AttributeType, Attributes},
+    compoundid,
     Result,
 };
 use native_pkcs11_traits::{backend, KeySearchOptions};
@@ -123,7 +124,8 @@ impl ObjectStore {
                     let key_search_opts = if let Some(Attribute::Id(id)) =
                         template.get(AttributeType::Id)
                     {
-                        KeySearchOptions::PublicKeyHash(id.as_slice().try_into()?)
+                        let id = compoundid::decode(id)?;
+                        KeySearchOptions::PublicKeyHash(id.public_key_hash.as_slice().try_into()?)
                     } else if let Some(Attribute::Label(label)) = template.get(AttributeType::Label)
                     {
                         KeySearchOptions::Label(label.into())


### PR DESCRIPTION
Some software (such as Burp Suite) assumes that every object has a unique Id attribute, even though this is not specified by the PKCS#11 spec.

This commit uses serde_bincode to encode both an optional Label and the PublicKeyHash into the Id. A limit of 2048 bytes is set to prevent memory overflow from adversarial input.

ObjectStore is modified to parse the public key hash from the Id, although the label is currently ignored in this case. We could potentially add a new `LabelAndHash` search method that each backend would have to implement.