### PR TITLE
Enable logging of span events to stderr

### DIFF
--- a/native-pkcs11/src/lib.rs
+++ b/native-pkcs11/src/lib.rs
@@ -20,7 +20,7 @@ pub use native_pkcs11_core::Error;
 use native_pkcs11_traits::backend;
 use tracing::metadata::LevelFilter;
 use tracing_error::ErrorLayer;
-use tracing_subscriber::{prelude::*, EnvFilter, Registry};
+use tracing_subscriber::{fmt::format::FmtSpan, prelude::*, EnvFilter, Registry};
 mod object_store;
 mod sessions;
 mod utils;
@@ -225,7 +225,11 @@ cryptoki_fn!(
                 }
             }
             _ = Registry::default()
-                .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .with_writer(std::io::stderr)
+                        .with_span_events(FmtSpan::ENTER),
+                )
                 .with(env_filter)
                 .with(ErrorLayer::default())
                 .try_init();

--- a/native-pkcs11/src/object_store.rs
+++ b/native-pkcs11/src/object_store.rs
@@ -41,7 +41,7 @@ pub struct ObjectStore {
 }
 
 impl ObjectStore {
-    #[instrument]
+    #[instrument(skip(self))]
     pub fn insert(&mut self, object: Object) -> CK_OBJECT_HANDLE {
         if let Some(existing_handle) = self.handles_by_object.get(&object) {
             return *existing_handle;
@@ -53,12 +53,12 @@ impl ObjectStore {
         handle
     }
 
-    #[instrument]
+    #[instrument(skip(self))]
     pub fn get(&self, handle: &CK_OBJECT_HANDLE) -> Option<&Object> {
         self.objects.get(handle)
     }
 
-    #[instrument]
+    #[instrument(skip(self))]
     pub fn find(&mut self, template: Attributes) -> Result<Vec<CK_OBJECT_HANDLE>> {
         let mut output = vec![];
         // Cache certificates.


### PR DESCRIPTION
Note: span events are logged at INFO level, and our default level filters to WARN, so this shouldn't cause any surprise log spam.