### PR TITLE
Release 0.2.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "native-pkcs11"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "native-pkcs11-core",
  "native-pkcs11-keychain",
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-core"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "bincode",
  "native-pkcs11-keychain",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-keychain"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "apple-security-framework",
  "apple-security-framework-sys",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-traits"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "once_cell",
  "rand",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-windows"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "native-pkcs11-traits",
  "windows",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs11-sys"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "bindgen",
 ]

--- a/native-pkcs11-core/Cargo.toml
+++ b/native-pkcs11-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-core"
-version = "0.2.15"
+version = "0.2.16"
 description = "Shared cross-platform PKCS#11 module logic for native-pkcs11."
 authors.workspace = true
 edition.workspace = true

--- a/native-pkcs11-keychain/Cargo.toml
+++ b/native-pkcs11-keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-keychain"
-version = "0.2.15"
+version = "0.2.16"
 description = "native-pkcs11 backend for macos keychain."
 authors.workspace = true
 edition.workspace = true

--- a/native-pkcs11-traits/Cargo.toml
+++ b/native-pkcs11-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-traits"
-version = "0.2.15"
+version = "0.2.16"
 description = "Traits for implementing and interactive with native-pkcs11 module backends."
 authors.workspace = true
 edition.workspace = true

--- a/native-pkcs11-windows/Cargo.toml
+++ b/native-pkcs11-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-windows"
-version = "0.2.15"
+version = "0.2.16"
 description = "[wip] native-pkcs11 backend for windows."
 authors.workspace = true
 edition.workspace = true

--- a/native-pkcs11/Cargo.toml
+++ b/native-pkcs11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11"
-version = "0.2.15"
+version = "0.2.16"
 description = "Cross-platform PKCS#11 module written in rust. Can be extended with custom credential backends."
 authors.workspace = true
 edition.workspace = true

--- a/pkcs11-sys/Cargo.toml
+++ b/pkcs11-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs11-sys"
-version = "0.2.15"
+version = "0.2.16"
 description = "Generated bindings for pkcs11.h. Useful for building PKCS#11 modules in rust."
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
native-pkcs11@0.2.16
native-pkcs11-core@0.2.16
native-pkcs11-keychain@0.2.16
native-pkcs11-traits@0.2.16
native-pkcs11-windows@0.2.16
pkcs11-sys@0.2.16

Generated by cargo-workspaces