### PR TITLE
Run `cargo test` on macOS during CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,14 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         uses: EmbarkStudios/cargo-deny-action@3f4a782664881cf5725d0ffd23969fcce89fd868 # v1.6.3
 
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - run: echo "NATIVE_PKCS11_KEYCHAIN_PATH=$RUNNER_TEMP/Test.keychain" >> $GITHUB_ENV
+      - run: security create-keychain -p '' "$NATIVE_PKCS11_KEYCHAIN_PATH"
+      - run: cargo test --verbose
+
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ pub extern "C" fn C_GetFunctionList(ppFunctionList: CK_FUNCTION_LIST_PTR_PTR) ->
 }
 ```
 
+## Running tests
+
+### macOS
+
+Create a tempory keychain and set `NATIVE_PKCS11_KEYCHAIN_PATH` to run `cargo test` without endless password prompts.
+```
+$ . tests/create_keychain.sh
+$ cargo test
+```
+
 ## Releasing
 
 The [`cargo-ws`](https://github.com/pksunkara/cargo-workspaces) tool can be used

--- a/native-pkcs11-keychain/src/macos/backend.rs
+++ b/native-pkcs11-keychain/src/macos/backend.rs
@@ -19,10 +19,7 @@ use core_foundation::{
     string::CFString,
 };
 use native_pkcs11_traits::Backend;
-use security_framework::{
-    item::{KeyClass, Location},
-    key::SecKey,
-};
+use security_framework::{item::KeyClass, key::SecKey};
 use security_framework_sys::item::kSecAttrLabel;
 use tracing::instrument;
 
@@ -37,6 +34,7 @@ use crate::{
         KeychainPrivateKey,
         KeychainPublicKey,
     },
+    keychain,
 };
 
 #[derive(Debug, Default)]
@@ -140,10 +138,8 @@ impl Backend for KeychainBackend {
             native_pkcs11_traits::KeyAlgorithm::Ecc => Algorithm::ECC,
         };
         let label = label.unwrap_or("");
-        Ok(
-            generate_key(alg, label, Some(Location::DefaultFileKeychain))
-                .map(|key| KeychainPrivateKey::new(key, label, None).map(Arc::new))??,
-        )
+        Ok(generate_key(alg, label, Some(keychain::location()?))
+            .map(|key| KeychainPrivateKey::new(key, label, None).map(Arc::new))??)
     }
 
     fn find_all_private_keys(

--- a/native-pkcs11-keychain/src/macos/key.rs
+++ b/native-pkcs11-keychain/src/macos/key.rs
@@ -352,12 +352,12 @@ mod test {
     use serial_test::serial;
 
     use super::*;
-    use crate::KeychainBackend;
+    use crate::{keychain, KeychainBackend};
     #[test]
     #[serial]
     fn key_label() -> crate::Result<()> {
         let label = random_label();
-        let key = generate_key(Algorithm::RSA, &label, Some(Location::DefaultFileKeychain))?;
+        let key = generate_key(Algorithm::RSA, &label, Some(keychain::location()?))?;
 
         let mut found = false;
         for res in crate::keychain::item_search_options()?
@@ -414,7 +414,7 @@ mod test {
         ] {
             let label = &random_label();
 
-            let key = generate_key(key_alg, label, Some(Location::DefaultFileKeychain))?;
+            let key = generate_key(key_alg, label, Some(keychain::location()?))?;
 
             let first_pubkey = key
                 .public_key()
@@ -451,7 +451,7 @@ mod test {
     fn stress_test_keygen() {
         let try_gen_key = || -> bool {
             let label = random_label();
-            match generate_key(Algorithm::RSA, &label, Some(Location::DefaultFileKeychain)) {
+            match generate_key(Algorithm::RSA, &label, Some(keychain::location().unwrap())) {
                 Ok(key) => {
                     let _ = key.delete();
                     true
@@ -478,16 +478,8 @@ mod test {
 
     #[test]
     fn keychain_pubkey_hash_find() -> Result<()> {
-        let key1 = generate_key(
-            Algorithm::ECC,
-            &random_label(),
-            Some(Location::DefaultFileKeychain),
-        )?;
-        let key2 = generate_key(
-            Algorithm::ECC,
-            &random_label(),
-            Some(Location::DefaultFileKeychain),
-        )?;
+        let key1 = generate_key(Algorithm::ECC, &random_label(), Some(keychain::location()?))?;
+        let key2 = generate_key(Algorithm::ECC, &random_label(), Some(keychain::location()?))?;
         assert_ne!(key1.application_label(), key2.application_label());
 
         for keyclass in [KeyClass::public(), KeyClass::private()] {

--- a/native-pkcs11-keychain/src/macos/mod.rs
+++ b/native-pkcs11-keychain/src/macos/mod.rs
@@ -25,11 +25,6 @@ pub mod certificate;
 pub mod key;
 pub mod keychain;
 
-//  NOTE(kcking): I think this just works because any non-System path defaults
-//  to the Login keychain
-pub const LOGIN_KEYCHAIN_PATH: &str = "login.keychain";
-pub const SYSTEM_KEYCHAIN_PATH: &str = "/Library/Keychains/System.keychain";
-
 pub type Result<T> = std::result::Result<T, Error>;
 
 pub struct Error {

--- a/tests/create_keychain.sh
+++ b/tests/create_keychain.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TMP_DIR=$(mktemp --directory)
+export NATIVE_PKCS11_KEYCHAIN_PATH="$TMP_DIR/native-pkcs11.keychain"
+security create-keychain -p '' "$NATIVE_PKCS11_KEYCHAIN_PATH"


### PR DESCRIPTION
- Refactor to always source the keychain from `macos::keychain`
- Add script for creating a tempoary keychain and setting `NATIVE_PKCS11_KEYCHAIN_PATH`
- Add a GitHub actions job for running `cargo test` on macOS
- Add instructions for running tests locally on macOS