### PR TITLE
Correct mechanism to sigalg mapping for RSA-SHA384/512

### DIFF
--- a/native-pkcs11-core/src/mechanism.rs
+++ b/native-pkcs11-core/src/mechanism.rs
@@ -131,8 +131,8 @@ impl From<Mechanism> for SignatureAlgorithm {
             Mechanism::RsaPkcs => SignatureAlgorithm::RsaPkcs1v15Raw,
             Mechanism::RsaPkcsSha1 => SignatureAlgorithm::RsaPkcs1v15Sha1,
             Mechanism::RsaPkcsSha256 => SignatureAlgorithm::RsaPkcs1v15Sha256,
-            Mechanism::RsaPkcsSha384 => SignatureAlgorithm::RsaPkcs1v15Sha512,
-            Mechanism::RsaPkcsSha512 => SignatureAlgorithm::RsaPkcs1v15Sha384,
+            Mechanism::RsaPkcsSha384 => SignatureAlgorithm::RsaPkcs1v15Sha384,
+            Mechanism::RsaPkcsSha512 => SignatureAlgorithm::RsaPkcs1v15Sha512,
             Mechanism::RsaPss {
                 digest_algorithm,
                 mask_generation_function,


### PR DESCRIPTION
The mapping from the Mechanism to SignatureAlgorithm contains a twisted value. The result is that RsaPkcsSha384 gets mapped to RsaPkcs1v15Sha512 and vice versa.