### PR TITLE
Migrate lazy initialization from once_cell to std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,6 @@ dependencies = [
  "native-pkcs11-keychain",
  "native-pkcs11-traits",
  "native-pkcs11-windows",
- "once_cell",
  "pkcs11-sys",
  "serial_test",
  "thiserror",
@@ -437,7 +436,6 @@ dependencies = [
  "native-pkcs11-keychain",
  "native-pkcs11-traits",
  "native-pkcs11-windows",
- "once_cell",
  "p256",
  "pkcs1",
  "pkcs11-sys",
@@ -471,7 +469,6 @@ dependencies = [
 name = "native-pkcs11-traits"
 version = "0.2.19"
 dependencies = [
- "once_cell",
  "rand",
  "x509-cert",
 ]

--- a/native-pkcs11-core/Cargo.toml
+++ b/native-pkcs11-core/Cargo.toml
@@ -10,7 +10,6 @@ license.workspace = true
 
 [dependencies]
 native-pkcs11-traits = { version = "0.2.0", path = "../native-pkcs11-traits" }
-once_cell = "1.19.0"
 p256 = { version = "0.13.2", default-features = false, features = [
     "arithmetic",
     "pkcs8",

--- a/native-pkcs11-traits/Cargo.toml
+++ b/native-pkcs11-traits/Cargo.toml
@@ -9,6 +9,5 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-once_cell = "1.19.0"
 rand = "0.8.5"
 x509-cert = { version = "0.2.5", default-features = false }

--- a/native-pkcs11-traits/src/lib.rs
+++ b/native-pkcs11-traits/src/lib.rs
@@ -18,8 +18,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-pub use once_cell;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use x509_cert::der::Decode;
 
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -28,8 +27,8 @@ pub type Digest = [u8; 20];
 //  The Backend is first staged so it can be stored in a Box<dyn Backend>. This
 //  allows the Backend to be reference with `&'static`.
 static STAGED_BACKEND: RwLock<Option<Box<dyn Backend>>> = RwLock::new(None);
-static BACKEND: Lazy<Box<dyn Backend>> =
-    Lazy::new(|| STAGED_BACKEND.write().unwrap().take().unwrap());
+static BACKEND: LazyLock<Box<dyn Backend>> =
+    LazyLock::new(|| STAGED_BACKEND.write().unwrap().take().unwrap());
 
 /// Stores a backend to later be returned by all calls `crate::backend()`.
 pub fn register_backend(backend: Box<dyn Backend>) {

--- a/native-pkcs11/Cargo.toml
+++ b/native-pkcs11/Cargo.toml
@@ -15,7 +15,6 @@ custom-function-list = []
 cached = { version = "0.52.0", default-features = false }
 native-pkcs11-core = { version = "^0.2.14", path = "../native-pkcs11-core" }
 native-pkcs11-traits = { version = "0.2.0", path = "../native-pkcs11-traits" }
-once_cell = "1.19.0"
 pkcs11-sys = { version = "0.2.0", path = "../pkcs11-sys" }
 thiserror = "1.0.62"
 tracing = "0.1.40"

--- a/native-pkcs11/src/sessions.rs
+++ b/native-pkcs11/src/sessions.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 use native_pkcs11_traits::{PrivateKey, SignatureAlgorithm};
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use pkcs11_sys::{CK_BYTE_PTR, CK_FLAGS, CK_OBJECT_HANDLE, CK_SESSION_HANDLE, CK_ULONG_PTR};
 
 use crate::{object_store::ObjectStore, Error, Result};
@@ -31,8 +31,8 @@ static NEXT_SESSION_HANDLE: std::sync::atomic::AtomicU32 = std::sync::atomic::At
 
 type SessionMap = HashMap<CK_SESSION_HANDLE, Session>;
 
-static SESSIONS: Lazy<sync::Mutex<SessionMap>> = Lazy::new(Default::default);
-pub static OBJECT_STORE: Lazy<sync::Mutex<ObjectStore>> = Lazy::new(Default::default);
+static SESSIONS: LazyLock<sync::Mutex<SessionMap>> = LazyLock::new(Default::default);
+pub static OBJECT_STORE: LazyLock<sync::Mutex<ObjectStore>> = LazyLock::new(Default::default);
 
 #[derive(Debug)]
 pub struct FindContext {


### PR DESCRIPTION

## What was changed
According to the official stable  Rust 1.80.0 release.  we now have LazyLock and LazyCell as part of the Standard Library(https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html). This PR upgrades all the `once_cell::sync::Lazy` to `std::sync::LazyLock` to ensure the code is current.

## Why?
- Keep code up to date

> [!WARNING]
This should only be merged after upgrading to `Rust 1.80.0` otherwise the merge will introduce a breaking change


## Checklist

- **How was this tested**: Still compiles. 
- **Any docs updates needed**: Don't think so.
