### PR TITLE
Silence invalid attribute type warnings

### DIFF
--- a/native-pkcs11/src/lib.rs
+++ b/native-pkcs11/src/lib.rs
@@ -65,7 +65,12 @@ where
     match f() {
         Ok(()) => CKR_OK,
         Err(e) => {
-            tracing::error!(%e);
+            match e {
+                // Some PKCS #11 return values indicate routine conditions that
+                // should not be logged at the default log level.
+                Error::AttributeTypeInvalid(_) => tracing::debug!(%e),
+                _ => tracing::error!(%e),
+            }
             e.into()
         }
     }


### PR DESCRIPTION
`CKR_ATTRIBUTE_TYPE_INVALID` indicates a routine condition. Logging at the WARN level causes the output of command-line tools to be polluted.

Fixes: #334