### PR TITLE
core: reasonable defaults for CKA_{DERIVE,LOCAL}

### DIFF
--- a/native-pkcs11-core/src/attribute.rs
+++ b/native-pkcs11-core/src/attribute.rs
@@ -29,6 +29,7 @@ pub enum AttributeType {
     Class,
     Coefficient,
     Decrypt,
+    Derive,
     EcParams,
     EcPoint,
     Encrypt,
@@ -39,6 +40,7 @@ pub enum AttributeType {
     Issuer,
     KeyType,
     Label,
+    Local,
     Modulus,
     ModulusBits,
     NeverExtractable,
@@ -76,6 +78,7 @@ impl TryFrom<CK_ATTRIBUTE_TYPE> for AttributeType {
             CKA_CLASS => Ok(AttributeType::Class),
             CKA_COEFFICIENT => Ok(AttributeType::Coefficient),
             CKA_DECRYPT => Ok(AttributeType::Decrypt),
+            CKA_DERIVE => Ok(AttributeType::Derive),
             CKA_EC_PARAMS => Ok(AttributeType::EcParams),
             CKA_EC_POINT => Ok(AttributeType::EcPoint),
             CKA_ENCRYPT => Ok(AttributeType::Encrypt),
@@ -86,6 +89,7 @@ impl TryFrom<CK_ATTRIBUTE_TYPE> for AttributeType {
             CKA_ISSUER => Ok(AttributeType::Issuer),
             CKA_KEY_TYPE => Ok(AttributeType::KeyType),
             CKA_LABEL => Ok(AttributeType::Label),
+            CKA_LOCAL => Ok(AttributeType::Local),
             CKA_MODULUS => Ok(AttributeType::Modulus),
             CKA_MODULUS_BITS => Ok(AttributeType::ModulusBits),
             CKA_NEVER_EXTRACTABLE => Ok(AttributeType::NeverExtractable),
@@ -123,6 +127,7 @@ pub enum Attribute {
     Class(CK_OBJECT_CLASS),
     Coefficient(Vec<u8>),
     Decrypt(bool),
+    Derive(bool),
     EcParams(Vec<u8>),
     EcPoint(Vec<u8>),
     Encrypt(bool),
@@ -133,6 +138,7 @@ pub enum Attribute {
     Issuer(Vec<u8>),
     KeyType(CK_KEY_TYPE),
     Label(String),
+    Local(bool),
     Modulus(Vec<u8>),
     ModulusBits(CK_ULONG),
     NeverExtractable(bool),
@@ -168,12 +174,14 @@ impl Attribute {
             Attribute::Class(_) => AttributeType::Class,
             Attribute::Coefficient(_) => AttributeType::Coefficient,
             Attribute::Decrypt(_) => AttributeType::Decrypt,
+            Attribute::Derive(_) => AttributeType::Derive,
             Attribute::EcParams(_) => AttributeType::EcParams,
             Attribute::EcPoint(_) => AttributeType::EcPoint,
             Attribute::Encrypt(_) => AttributeType::Encrypt,
             Attribute::Exponent1(_) => AttributeType::Exponent1,
             Attribute::Exponent2(_) => AttributeType::Exponent2,
             Attribute::Extractable(_) => AttributeType::Extractable,
+            Attribute::Local(_) => AttributeType::Local,
             Attribute::Id(_) => AttributeType::Id,
             Attribute::Issuer(_) => AttributeType::Issuer,
             Attribute::KeyType(_) => AttributeType::KeyType,
@@ -208,8 +216,10 @@ impl Attribute {
             Attribute::AlwaysAuthenticate(bool)
             | Attribute::AlwaysSensitive(bool)
             | Attribute::Decrypt(bool)
+            | Attribute::Derive(bool)
             | Attribute::Encrypt(bool)
             | Attribute::Extractable(bool)
+            | Attribute::Local(bool)
             | Attribute::NeverExtractable(bool)
             | Attribute::Private(bool)
             | Attribute::Sensitive(bool)
@@ -290,6 +300,7 @@ impl TryFrom<CK_ATTRIBUTE> for Attribute {
             ))),
             AttributeType::Coefficient => Ok(Attribute::Coefficient(val.to_vec())),
             AttributeType::Decrypt => Ok(Attribute::Decrypt(try_u8_into_bool(val)?)),
+            AttributeType::Derive => Ok(Attribute::Derive(try_u8_into_bool(val)?)),
             AttributeType::EcParams => Ok(Attribute::EcParams(val.to_vec())),
             AttributeType::EcPoint => Ok(Attribute::EcPoint(val.to_vec())),
             AttributeType::Encrypt => Ok(Attribute::Encrypt(try_u8_into_bool(val)?)),
@@ -302,6 +313,7 @@ impl TryFrom<CK_ATTRIBUTE> for Attribute {
                 val.try_into()?,
             ))),
             AttributeType::Label => Ok(Attribute::Label(String::from_utf8(val.to_vec())?)),
+            AttributeType::Local => Ok(Attribute::Local(try_u8_into_bool(val)?)),
             AttributeType::Modulus => Ok(Attribute::Modulus(val.to_vec())),
             AttributeType::ModulusBits => Ok(Attribute::ModulusBits(CK_ULONG::from_ne_bytes(
                 val.try_into()?,

--- a/native-pkcs11-core/src/object.rs
+++ b/native-pkcs11-core/src/object.rs
@@ -101,6 +101,7 @@ impl Object {
                 AttributeType::AlwaysAuthenticate => Some(Attribute::AlwaysAuthenticate(false)),
                 AttributeType::Class => Some(Attribute::Class(CKO_PRIVATE_KEY)),
                 AttributeType::Decrypt => Some(Attribute::Decrypt(false)),
+                AttributeType::Derive => Some(Attribute::Derive(false)),
                 AttributeType::EcParams => {
                     Some(Attribute::EcParams(p256::NistP256::OID.to_der().ok()?))
                 }
@@ -111,6 +112,7 @@ impl Object {
                     native_pkcs11_traits::KeyAlgorithm::Ecc => CKK_EC,
                 })),
                 AttributeType::Label => Some(Attribute::Label(private_key.label())),
+                AttributeType::Local => Some(Attribute::Local(false)),
                 AttributeType::Modulus => {
                     let modulus = private_key
                         .find_public_key(backend())
@@ -160,7 +162,9 @@ impl Object {
             },
             Object::PublicKey(pk) => match type_ {
                 AttributeType::Class => Some(Attribute::Class(CKO_PUBLIC_KEY)),
+                AttributeType::Derive => Some(Attribute::Derive(false)),
                 AttributeType::Label => Some(Attribute::Label(pk.label())),
+                AttributeType::Local => Some(Attribute::Local(false)),
                 AttributeType::Modulus => {
                     let key = pk.to_der();
                     let key = RsaPublicKey::from_der(&key).unwrap();


### PR DESCRIPTION
These attributes are described in 4.7.2. The main impetus is to make interacting with native-pkcs11 using pkcs11-tool print fewer warnings. Without this pkcs11-tool prints a couple errant warnings when listing objects:

```
warning: PKCS11 function C_GetAttributeValue(DERIVE) failed: rv = CKR_ATTRIBUTE_TYPE_INVALID (0x12)
warning: PKCS11 function C_GetAttributeValue(LOCAL) failed: rv = CKR_ATTRIBUTE_TYPE_INVALID (0x12)
```

Derive being false makes sense because native-pkcs11 doewsn't support the C_DeriveKey func. Local is less clear and one could argue it could be left to the backend to determine, but I think starting with a hardcoded false value is reasonable.