### PR TITLE
Support for EC keys, fix Attributes processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,7 @@ dependencies = [
  "pkcs11-sys",
  "pkcs8",
  "serial_test",
+ "spki",
  "strum",
  "strum_macros",
  "thiserror 2.0.11",

--- a/native-pkcs11-core/Cargo.toml
+++ b/native-pkcs11-core/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 [dependencies]
 der = "0.7.9"
 native-pkcs11-traits = { version = "0.2.0", path = "../native-pkcs11-traits" }
+spki = "0.7"
 pkcs1 = { version = "0.7.5", default-features = false }
 pkcs11-sys = { version = "0.2.24", path = "../pkcs11-sys" }
 pkcs8 = "0.10.2"

--- a/native-pkcs11-traits/src/lib.rs
+++ b/native-pkcs11-traits/src/lib.rs
@@ -21,7 +21,7 @@ use std::{
 use x509_cert::der::Decode;
 
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
-pub type Digest = [u8; 20];
+pub type Digest = [u8; 64];
 
 //  The Backend is first staged so it can be stored in a Box<dyn Backend>. This
 //  allows the Backend to be reference with `&'static`.

--- a/native-pkcs11/src/object_store.rs
+++ b/native-pkcs11/src/object_store.rs
@@ -171,8 +171,8 @@ impl ObjectStore {
     }
 
     fn find_with_backend_all_public_keys(&mut self) -> Result<()> {
-        for private_key in backend().find_all_private_keys()? {
-            self.insert(Object::PrivateKey(private_key));
+        for public_key in backend().find_all_public_keys()? {
+            self.insert(Object::PublicKey(public_key));
         }
         Ok(())
     }


### PR DESCRIPTION
This change adds proper handling for EC keys (addressing https://github.com/google/native-pkcs11/issues/303) as well as proper RSA parameters calculation.

NOTE: For instance, openssl expects that EC params (curve OID) and points are in specific uncompressed and padded format. In Go encoding EC_POINTS be like:

```go
case C.CKA_EC_POINT:
    encodedPoint, err := encodeECPoint(key.Curve, key.X, key.Y)
    ...
    setValue(attr, unsafe.Pointer(&encodedPoint[0]), C.CK_ULONG(len(encodedPoint)))

func encodeECPoint(curve elliptic.Curve, x, y *big.Int) ([]byte, error) {
        fieldSize := (curve.Params().BitSize + 7) / 8
        xPadded := make([]byte, fieldSize)
        yPadded := make([]byte, fieldSize)
        copy(xPadded[fieldSize-len(x.Bytes()):], x.Bytes())
        copy(yPadded[fieldSize-len(y.Bytes()):], y.Bytes())

        ecPoint := append([]byte{0x04}, append(xPadded, yPadded...)...)

        return asn1.Marshal(asn1.RawValue{
                Tag:   asn1.TagOctetString,
                Bytes: ecPoint,
        })
}
```
I faced this issue when implementing fake custom backend using regular PEM/DER files or passing signature produced by AWS KMS.
Perhaps, as later improvement we can try to instantiate specific signature from DER bytes and then repack params into expected format. Now this is offloaded to the backend.

The changes were checked with my custom backend using RSA2048 and ECC NIST-P256 keys via OpenSSL.