### PR TITLE
chore: release v0.2.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "native-pkcs11"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "cached",
  "native-pkcs11-core",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-core"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "der",
  "native-pkcs11-keychain",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-keychain"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "core-foundation",
  "native-pkcs11-traits",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-windows"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "native-pkcs11-traits",
  "windows",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs11-sys"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "bindgen",
 ]

--- a/native-pkcs11-core/Cargo.toml
+++ b/native-pkcs11-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-core"
-version = "0.2.23"
+version = "0.2.24"
 description = "Shared cross-platform PKCS#11 module logic for native-pkcs11."
 authors.workspace = true
 edition.workspace = true
@@ -12,7 +12,7 @@ license.workspace = true
 der = "0.7.9"
 native-pkcs11-traits = { version = "0.2.0", path = "../native-pkcs11-traits" }
 pkcs1 = { version = "0.7.5", default-features = false }
-pkcs11-sys = { version = "0.2.0", path = "../pkcs11-sys" }
+pkcs11-sys = { version = "0.2.24", path = "../pkcs11-sys" }
 pkcs8 = "0.10.2"
 strum = "0.26"
 strum_macros = "0.26"
@@ -23,7 +23,7 @@ tracing = "0.1.41"
 serial_test = { version = "3.2.0", default-features = false }
 
 [target.'cfg(target_os="macos")'.dependencies]
-native-pkcs11-keychain = { version = "0.2.0", path = "../native-pkcs11-keychain" }
+native-pkcs11-keychain = { version = "0.2.24", path = "../native-pkcs11-keychain" }
 
 [target.'cfg(target_os="windows")'.dependencies]
-native-pkcs11-windows = { version = "0.2.0", path = "../native-pkcs11-windows" }
+native-pkcs11-windows = { version = "0.2.24", path = "../native-pkcs11-windows" }

--- a/native-pkcs11-keychain/Cargo.toml
+++ b/native-pkcs11-keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-keychain"
-version = "0.2.23"
+version = "0.2.24"
 description = "native-pkcs11 backend for macos keychain."
 authors.workspace = true
 edition.workspace = true

--- a/native-pkcs11-windows/Cargo.toml
+++ b/native-pkcs11-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-windows"
-version = "0.2.23"
+version = "0.2.24"
 description = "[wip] native-pkcs11 backend for windows."
 authors.workspace = true
 edition.workspace = true

--- a/native-pkcs11/Cargo.toml
+++ b/native-pkcs11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11"
-version = "0.2.23"
+version = "0.2.24"
 description = "Cross-platform PKCS#11 module written in rust. Can be extended with custom credential backends."
 authors.workspace = true
 edition.workspace = true
@@ -13,9 +13,9 @@ custom-function-list = []
 
 [dependencies]
 cached = { version = "~0.54", default-features = false }
-native-pkcs11-core = { version = "^0.2.14", path = "../native-pkcs11-core" }
+native-pkcs11-core = { version = "^0.2.24", path = "../native-pkcs11-core" }
 native-pkcs11-traits = { version = "0.2.0", path = "../native-pkcs11-traits" }
-pkcs11-sys = { version = "0.2.0", path = "../pkcs11-sys" }
+pkcs11-sys = { version = "0.2.24", path = "../pkcs11-sys" }
 thiserror = "2"
 tracing = "0.1.41"
 tracing-error = "0.2.1"
@@ -33,7 +33,7 @@ tracing-subscriber = { version = "0.3.19", default-features = false, features = 
 ] }
 
 [target.'cfg(target_os="macos")'.dependencies]
-native-pkcs11-keychain = { version = "0.2.0", path = "../native-pkcs11-keychain" }
+native-pkcs11-keychain = { version = "0.2.24", path = "../native-pkcs11-keychain" }
 
 [target.'cfg(target_os="windows")'.dependencies]
-native-pkcs11-windows = { version = "0.2.0", path = "../native-pkcs11-windows" }
+native-pkcs11-windows = { version = "0.2.24", path = "../native-pkcs11-windows" }

--- a/pkcs11-sys/Cargo.toml
+++ b/pkcs11-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs11-sys"
-version = "0.2.23"
+version = "0.2.24"
 description = "Generated bindings for pkcs11.h. Useful for building PKCS#11 modules in rust."
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `native-pkcs11-core`: 0.2.23 -> 0.2.24 (✓ API compatible changes)
* `pkcs11-sys`: 0.2.23 -> 0.2.24 (✓ API compatible changes)
* `native-pkcs11-keychain`: 0.2.23 -> 0.2.24 (✓ API compatible changes)
* `native-pkcs11-windows`: 0.2.23 -> 0.2.24 (✓ API compatible changes)
* `native-pkcs11`: 0.2.23 -> 0.2.24

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).