### PR TITLE
Early logging initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "ctor"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +277,7 @@ name = "native-pkcs11"
 version = "0.2.24"
 dependencies = [
  "cached",
+ "ctor",
  "native-pkcs11-core",
  "native-pkcs11-keychain",
  "native-pkcs11-traits",

--- a/native-pkcs11/Cargo.toml
+++ b/native-pkcs11/Cargo.toml
@@ -12,6 +12,7 @@ license.workspace = true
 custom-function-list = []
 
 [dependencies]
+ctor = { version = "0.2" }
 cached = { version = "~0.54", default-features = false }
 native-pkcs11-core = { version = "^0.2.24", path = "../native-pkcs11-core" }
 native-pkcs11-traits = { version = "0.2.0", path = "../native-pkcs11-traits" }


### PR DESCRIPTION
In this PR the logging function moved away from C_Initialize under `ctor` when library is being loaded. This allows to start logging custom backend initialization. Also the log init function reworked to remove log lines duplication by using ` tracing::subscriber::set_global_default(...)`.
