### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "native-pkcs11"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "cached",
  "native-pkcs11-core",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-core"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "der",
  "native-pkcs11-keychain",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-keychain"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "core-foundation",
  "native-pkcs11-traits",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-traits"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "rand",
  "x509-cert",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-windows"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "native-pkcs11-traits",
  "windows",
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs11-sys"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "bindgen",
 ]

--- a/native-pkcs11-core/Cargo.toml
+++ b/native-pkcs11-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-core"
-version = "0.2.24"
+version = "0.2.25"
 description = "Shared cross-platform PKCS#11 module logic for native-pkcs11."
 authors.workspace = true
 edition.workspace = true
@@ -10,9 +10,9 @@ license.workspace = true
 
 [dependencies]
 der = "0.7.9"
-native-pkcs11-traits = { version = "0.2.0", path = "../native-pkcs11-traits" }
+native-pkcs11-traits = { version = "0.2.24", path = "../native-pkcs11-traits" }
 pkcs1 = { version = "0.7.5", default-features = false }
-pkcs11-sys = { version = "0.2.24", path = "../pkcs11-sys" }
+pkcs11-sys = { version = "0.2.25", path = "../pkcs11-sys" }
 pkcs8 = "0.10.2"
 strum = "0.26"
 strum_macros = "0.26"
@@ -23,7 +23,7 @@ tracing = "0.1.41"
 serial_test = { version = "3.2.0", default-features = false }
 
 [target.'cfg(target_os="macos")'.dependencies]
-native-pkcs11-keychain = { version = "0.2.24", path = "../native-pkcs11-keychain" }
+native-pkcs11-keychain = { version = "0.2.25", path = "../native-pkcs11-keychain" }
 
 [target.'cfg(target_os="windows")'.dependencies]
-native-pkcs11-windows = { version = "0.2.24", path = "../native-pkcs11-windows" }
+native-pkcs11-windows = { version = "0.2.25", path = "../native-pkcs11-windows" }

--- a/native-pkcs11-core/src/attribute.rs
+++ b/native-pkcs11-core/src/attribute.rs
@@ -286,18 +286,18 @@ impl TryFrom<CK_ATTRIBUTE> for Attribute {
             AttributeType::AlwaysSensitive => {
                 Ok(Attribute::AlwaysSensitive(try_u8_into_bool(val)?))
             }
-            AttributeType::Application => Ok(Attribute::Application(CString::from_vec_with_nul(
-                val.to_vec(),
-            )?)),
+            AttributeType::Application => {
+                Ok(Attribute::Application(CString::from_vec_with_nul(val.to_vec())?))
+            }
             AttributeType::CertificateCategory => Ok(Attribute::CertificateCategory(
                 CK_CERTIFICATE_CATEGORY::from_ne_bytes(val.try_into()?),
             )),
-            AttributeType::CertificateType => Ok(Attribute::CertificateType(
-                CK_CERTIFICATE_TYPE::from_ne_bytes(val.try_into()?),
-            )),
-            AttributeType::Class => Ok(Attribute::Class(CK_OBJECT_CLASS::from_ne_bytes(
-                val.try_into()?,
-            ))),
+            AttributeType::CertificateType => {
+                Ok(Attribute::CertificateType(CK_CERTIFICATE_TYPE::from_ne_bytes(val.try_into()?)))
+            }
+            AttributeType::Class => {
+                Ok(Attribute::Class(CK_OBJECT_CLASS::from_ne_bytes(val.try_into()?)))
+            }
             AttributeType::Coefficient => Ok(Attribute::Coefficient(val.to_vec())),
             AttributeType::Decrypt => Ok(Attribute::Decrypt(try_u8_into_bool(val)?)),
             AttributeType::Derive => Ok(Attribute::Derive(try_u8_into_bool(val)?)),
@@ -309,15 +309,15 @@ impl TryFrom<CK_ATTRIBUTE> for Attribute {
             AttributeType::Extractable => Ok(Attribute::Extractable(try_u8_into_bool(val)?)),
             AttributeType::Id => Ok(Attribute::Id(val.to_vec())),
             AttributeType::Issuer => Ok(Attribute::Issuer(val.to_vec())),
-            AttributeType::KeyType => Ok(Attribute::KeyType(CK_KEY_TYPE::from_ne_bytes(
-                val.try_into()?,
-            ))),
+            AttributeType::KeyType => {
+                Ok(Attribute::KeyType(CK_KEY_TYPE::from_ne_bytes(val.try_into()?)))
+            }
             AttributeType::Label => Ok(Attribute::Label(String::from_utf8(val.to_vec())?)),
             AttributeType::Local => Ok(Attribute::Local(try_u8_into_bool(val)?)),
             AttributeType::Modulus => Ok(Attribute::Modulus(val.to_vec())),
-            AttributeType::ModulusBits => Ok(Attribute::ModulusBits(CK_ULONG::from_ne_bytes(
-                val.try_into()?,
-            ))),
+            AttributeType::ModulusBits => {
+                Ok(Attribute::ModulusBits(CK_ULONG::from_ne_bytes(val.try_into()?)))
+            }
             AttributeType::NeverExtractable => {
                 Ok(Attribute::NeverExtractable(try_u8_into_bool(val)?))
             }
@@ -325,9 +325,9 @@ impl TryFrom<CK_ATTRIBUTE> for Attribute {
             AttributeType::Prime2 => Ok(Attribute::Prime2(val.to_vec())),
             AttributeType::Private => Ok(Attribute::Private(try_u8_into_bool(val)?)),
             AttributeType::PrivateExponent => Ok(Attribute::PrivateExponent(val.to_vec())),
-            AttributeType::ProfileId => Ok(Attribute::ProfileId(CK_ULONG::from_ne_bytes(
-                val.try_into()?,
-            ))),
+            AttributeType::ProfileId => {
+                Ok(Attribute::ProfileId(CK_ULONG::from_ne_bytes(val.try_into()?)))
+            }
             AttributeType::PublicExponent => Ok(Attribute::PublicExponent(val.to_vec())),
             AttributeType::Sensitive => Ok(Attribute::Sensitive(try_u8_into_bool(val)?)),
             AttributeType::SerialNumber => Ok(Attribute::SerialNumber(val.to_vec())),
@@ -338,9 +338,9 @@ impl TryFrom<CK_ATTRIBUTE> for Attribute {
             AttributeType::Trusted => Ok(Attribute::Trusted(try_u8_into_bool(val)?)),
             AttributeType::Unwrap => Ok(Attribute::Unwrap(try_u8_into_bool(val)?)),
             AttributeType::Value => Ok(Attribute::Value(val.to_vec())),
-            AttributeType::ValueLen => Ok(Attribute::ValueLen(CK_ULONG::from_ne_bytes(
-                val.try_into()?,
-            ))),
+            AttributeType::ValueLen => {
+                Ok(Attribute::ValueLen(CK_ULONG::from_ne_bytes(val.try_into()?)))
+            }
             AttributeType::Verify => Ok(Attribute::Verify(try_u8_into_bool(val)?)),
             AttributeType::VerifyRecover => Ok(Attribute::VerifyRecover(try_u8_into_bool(val)?)),
             AttributeType::Wrap => Ok(Attribute::Wrap(try_u8_into_bool(val)?)),

--- a/native-pkcs11-core/src/mechanism.rs
+++ b/native-pkcs11-core/src/mechanism.rs
@@ -133,15 +133,13 @@ impl From<Mechanism> for SignatureAlgorithm {
             Mechanism::RsaPkcsSha256 => SignatureAlgorithm::RsaPkcs1v15Sha256,
             Mechanism::RsaPkcsSha384 => SignatureAlgorithm::RsaPkcs1v15Sha384,
             Mechanism::RsaPkcsSha512 => SignatureAlgorithm::RsaPkcs1v15Sha512,
-            Mechanism::RsaPss {
-                digest_algorithm,
-                mask_generation_function,
-                salt_length,
-            } => SignatureAlgorithm::RsaPss {
-                digest: digest_algorithm,
-                mask_generation_function,
-                salt_length,
-            },
+            Mechanism::RsaPss { digest_algorithm, mask_generation_function, salt_length } => {
+                SignatureAlgorithm::RsaPss {
+                    digest: digest_algorithm,
+                    mask_generation_function,
+                    salt_length,
+                }
+            }
         }
     }
 }

--- a/native-pkcs11-core/src/object.rs
+++ b/native-pkcs11-core/src/object.rs
@@ -78,9 +78,9 @@ impl Object {
     pub fn attribute(&self, type_: AttributeType) -> Option<Attribute> {
         match self {
             Object::Certificate(cert) => match type_ {
-                AttributeType::CertificateCategory => Some(Attribute::CertificateCategory(
-                    CK_CERTIFICATE_CATEGORY_UNSPECIFIED,
-                )),
+                AttributeType::CertificateCategory => {
+                    Some(Attribute::CertificateCategory(CK_CERTIFICATE_CATEGORY_UNSPECIFIED))
+                }
                 AttributeType::CertificateType => Some(Attribute::CertificateType(CKC_X_509)),
                 AttributeType::Class => Some(Attribute::Class(CKO_CERTIFICATE)),
                 AttributeType::Id => Some(Attribute::Id(cert.public_key().public_key_hash())),
@@ -112,31 +112,28 @@ impl Object {
                 AttributeType::Label => Some(Attribute::Label(private_key.label())),
                 AttributeType::Local => Some(Attribute::Local(false)),
                 AttributeType::Modulus => {
-                    let modulus = private_key
-                        .find_public_key(backend())
-                        .ok()
-                        .flatten()
-                        .and_then(|public_key| {
+                    let modulus = private_key.find_public_key(backend()).ok().flatten().and_then(
+                        |public_key| {
                             let der = public_key.to_der();
                             RsaPublicKey::from_der(&der)
                                 .map(|pk| pk.modulus.as_bytes().to_vec())
                                 .ok()
-                        });
+                        },
+                    );
                     modulus.map(Attribute::Modulus)
                 }
                 AttributeType::NeverExtractable => Some(Attribute::NeverExtractable(true)),
                 AttributeType::Private => Some(Attribute::Private(true)),
                 AttributeType::PublicExponent => {
-                    let public_exponent = private_key
-                        .find_public_key(backend())
-                        .ok()
-                        .flatten()
-                        .and_then(|public_key| {
-                            let der = public_key.to_der();
-                            RsaPublicKey::from_der(&der)
-                                .map(|pk| pk.public_exponent.as_bytes().to_vec())
-                                .ok()
-                        });
+                    let public_exponent =
+                        private_key.find_public_key(backend()).ok().flatten().and_then(
+                            |public_key| {
+                                let der = public_key.to_der();
+                                RsaPublicKey::from_der(&der)
+                                    .map(|pk| pk.public_exponent.as_bytes().to_vec())
+                                    .ok()
+                            },
+                        );
                     public_exponent.map(Attribute::PublicExponent)
                 }
                 AttributeType::Sensitive => Some(Attribute::Sensitive(true)),

--- a/native-pkcs11-keychain/Cargo.toml
+++ b/native-pkcs11-keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-keychain"
-version = "0.2.24"
+version = "0.2.25"
 description = "native-pkcs11 backend for macos keychain."
 authors.workspace = true
 edition.workspace = true
@@ -9,7 +9,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-native-pkcs11-traits = { version = "0.2.23", path = "../native-pkcs11-traits" }
+native-pkcs11-traits = { version = "0.2.24", path = "../native-pkcs11-traits" }
 thiserror = "2"
 tracing = "0.1.41"
 tracing-error = { version = "0.2.1", default-features = false }

--- a/native-pkcs11-keychain/src/macos/backend.rs
+++ b/native-pkcs11-keychain/src/macos/backend.rs
@@ -149,10 +149,8 @@ impl Backend for KeychainBackend {
         let keys = sec_keys
             .into_iter()
             .filter_map(|sec_key| {
-                let label: Option<String> = sec_key
-                    .attributes()
-                    .find(unsafe { kSecAttrLabel }.to_void())
-                    .map(|label| {
+                let label: Option<String> =
+                    sec_key.attributes().find(unsafe { kSecAttrLabel }.to_void()).map(|label| {
                         unsafe { CFString::wrap_under_get_rule(label.cast()) }.to_string()
                     });
                 let label: String = label.unwrap_or_default();
@@ -172,10 +170,8 @@ impl Backend for KeychainBackend {
         let keys = sec_keys
             .into_iter()
             .filter_map(|sec_key| {
-                let label: Option<String> = sec_key
-                    .attributes()
-                    .find(unsafe { kSecAttrLabel }.to_void())
-                    .map(|label| {
+                let label: Option<String> =
+                    sec_key.attributes().find(unsafe { kSecAttrLabel }.to_void()).map(|label| {
                         unsafe { CFString::wrap_under_get_rule(label.cast()) }.to_string()
                     });
                 let label: String = label.unwrap_or_default();

--- a/native-pkcs11-keychain/src/macos/key.rs
+++ b/native-pkcs11-keychain/src/macos/key.rs
@@ -160,10 +160,7 @@ impl PrivateKey for KeychainPrivateKey {
 
 fn sec_key_algorithm(sec_key: &SecKey) -> Result<KeyAlgorithm> {
     let attributes = sec_key.attributes();
-    if attributes
-        .find(unsafe { kSecAttrTokenID }.to_void())
-        .is_some()
-    {
+    if attributes.find(unsafe { kSecAttrTokenID }.to_void()).is_some() {
         //  The only possible kSecAttrtokenID is kSecAttrTokenIDSecureEnclave.
         //
         //  SecureEnclave keys do not have kSecAttrKeyType populated, but we can
@@ -194,9 +191,7 @@ pub struct KeychainPublicKey {
 impl KeychainPublicKey {
     #[instrument]
     pub fn new(sec_key: SecKey, label: impl Into<String> + Debug) -> Result<Self> {
-        let der = sec_key
-            .external_representation()
-            .ok_or("no external representation")?;
+        let der = sec_key.external_representation().ok_or("no external representation")?;
         let key_ty = sec_key_algorithm(&sec_key)?;
         Ok(Self {
             public_key_hash: sec_key.application_label().ok_or("no application_label")?,
@@ -396,14 +391,8 @@ mod test {
     #[serial]
     fn key_lifecycle() -> Result<()> {
         for (key_alg, sig_alg) in [
-            (
-                Algorithm::ECC,
-                security_framework_sys::key::Algorithm::ECDSASignatureDigestX962,
-            ),
-            (
-                Algorithm::RSA,
-                security_framework_sys::key::Algorithm::RSASignatureDigestPKCS1v15Raw,
-            ),
+            (Algorithm::ECC, security_framework_sys::key::Algorithm::ECDSASignatureDigestX962),
+            (Algorithm::RSA, security_framework_sys::key::Algorithm::RSASignatureDigestPKCS1v15Raw),
         ] {
             let label = &random_label();
 
@@ -427,10 +416,7 @@ mod test {
             let sig_valid = loaded_pubkey.verify_signature(sig_alg, &payload, &signature)?;
             assert!(sig_valid);
 
-            assert_eq!(
-                loaded_pubkey.external_representation().unwrap().to_vec(),
-                first_pubkey
-            );
+            assert_eq!(loaded_pubkey.external_representation().unwrap().to_vec(), first_pubkey);
 
             loaded_key.public_key().ok_or("no pubkey")?.delete()?;
             loaded_key.delete()?;
@@ -505,18 +491,14 @@ mod test {
 
         let label = random_label();
         let key1 = SecKey::new(
-            GenerateKeyOptions::default()
-                .set_key_type(KeyType::ec())
-                .set_label(&label),
+            GenerateKeyOptions::default().set_key_type(KeyType::ec()).set_label(&label),
         )?;
 
         let pubkey_hash = key1.public_key().unwrap().application_label().unwrap();
 
-        ItemAddOptions::new(security_framework::item::ItemAddValue::Ref(AddRef::Key(
-            key1,
-        )))
-        .set_label(&label)
-        .add()?;
+        ItemAddOptions::new(security_framework::item::ItemAddValue::Ref(AddRef::Key(key1)))
+            .set_label(&label)
+            .add()?;
 
         //  NOTE(kcking): this fails to find the generated key, most likely
         //  because application_label is not automatically populated by

--- a/native-pkcs11-keychain/src/macos/mod.rs
+++ b/native-pkcs11-keychain/src/macos/mod.rs
@@ -43,10 +43,7 @@ impl std::error::Error for Error {}
 
 impl<E: Into<ErrorKind>> From<E> for Error {
     fn from(e: E) -> Self {
-        Error {
-            error: e.into(),
-            context: SpanTrace::capture(),
-        }
+        Error { error: e.into(), context: SpanTrace::capture() }
     }
 }
 

--- a/native-pkcs11-traits/Cargo.toml
+++ b/native-pkcs11-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-traits"
-version = "0.2.23"
+version = "0.2.24"
 description = "Traits for implementing and interactive with native-pkcs11 module backends."
 authors.workspace = true
 edition.workspace = true

--- a/native-pkcs11-traits/src/lib.rs
+++ b/native-pkcs11-traits/src/lib.rs
@@ -68,11 +68,7 @@ pub enum SignatureAlgorithm {
     RsaPkcs1v15Sha384,
     RsaPkcs1v15Sha256,
     RsaPkcs1v15Sha512,
-    RsaPss {
-        digest: DigestType,
-        mask_generation_function: DigestType,
-        salt_length: u64,
-    },
+    RsaPss { digest: DigestType, mask_generation_function: DigestType, salt_length: u64 },
 }
 
 pub trait PrivateKey: Send + Sync {
@@ -89,9 +85,7 @@ pub trait PrivateKey: Send + Sync {
 
 impl std::fmt::Debug for dyn PrivateKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PrivateKey")
-            .field("label", &self.label())
-            .finish_non_exhaustive()
+        f.debug_struct("PrivateKey").field("label", &self.label()).finish_non_exhaustive()
     }
 }
 
@@ -211,9 +205,5 @@ pub trait Backend: Send + Sync {
 pub fn random_label() -> String {
     use rand::{distr::Alphanumeric, Rng};
     String::from("bumpkey ")
-        + &rand::rng()
-            .sample_iter(&Alphanumeric)
-            .take(32)
-            .map(char::from)
-            .collect::<String>()
+        + &rand::rng().sample_iter(&Alphanumeric).take(32).map(char::from).collect::<String>()
 }

--- a/native-pkcs11-windows/Cargo.toml
+++ b/native-pkcs11-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-windows"
-version = "0.2.24"
+version = "0.2.25"
 description = "[wip] native-pkcs11 backend for windows."
 authors.workspace = true
 edition.workspace = true
@@ -9,7 +9,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-native-pkcs11-traits = { version = "0.2.0", path = "../native-pkcs11-traits" }
+native-pkcs11-traits = { version = "0.2.24", path = "../native-pkcs11-traits" }
 
 [target.'cfg(target_os="windows")'.dependencies.windows]
 version = "0.59.0"

--- a/native-pkcs11/Cargo.toml
+++ b/native-pkcs11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11"
-version = "0.2.24"
+version = "0.2.25"
 description = "Cross-platform PKCS#11 module written in rust. Can be extended with custom credential backends."
 authors.workspace = true
 edition.workspace = true
@@ -13,9 +13,9 @@ custom-function-list = []
 
 [dependencies]
 cached = { version = "~0.54", default-features = false }
-native-pkcs11-core = { version = "^0.2.24", path = "../native-pkcs11-core" }
-native-pkcs11-traits = { version = "0.2.0", path = "../native-pkcs11-traits" }
-pkcs11-sys = { version = "0.2.24", path = "../pkcs11-sys" }
+native-pkcs11-core = { version = "^0.2.25", path = "../native-pkcs11-core" }
+native-pkcs11-traits = { version = "0.2.24", path = "../native-pkcs11-traits" }
+pkcs11-sys = { version = "0.2.25", path = "../pkcs11-sys" }
 thiserror = "2"
 tracing = "0.1.41"
 tracing-error = "0.2.1"
@@ -33,7 +33,7 @@ tracing-subscriber = { version = "0.3.19", default-features = false, features = 
 ] }
 
 [target.'cfg(target_os="macos")'.dependencies]
-native-pkcs11-keychain = { version = "0.2.24", path = "../native-pkcs11-keychain" }
+native-pkcs11-keychain = { version = "0.2.25", path = "../native-pkcs11-keychain" }
 
 [target.'cfg(target_os="windows")'.dependencies]
-native-pkcs11-windows = { version = "0.2.24", path = "../native-pkcs11-windows" }
+native-pkcs11-windows = { version = "0.2.25", path = "../native-pkcs11-windows" }

--- a/native-pkcs11/src/lib.rs
+++ b/native-pkcs11/src/lib.rs
@@ -401,10 +401,7 @@ cryptoki_fn!(
         if !SUPPORTED_SIGNATURE_MECHANISMS.contains(&mechType) {
             return Err(Error::MechanismInvalid(mechType));
         }
-        let info = CK_MECHANISM_INFO {
-            flags: CKF_SIGN,
-            ..Default::default()
-        };
+        let info = CK_MECHANISM_INFO { flags: CKF_SIGN, ..Default::default() };
         unsafe { *pInfo = info };
         Ok(())
     }
@@ -489,17 +486,9 @@ cryptoki_fn!(
         valid_session!(hSession);
         not_null!(pInfo);
         let flags = sessions::flags(hSession);
-        let state = if flags & CKF_RW_SESSION == 0 {
-            CKS_RO_USER_FUNCTIONS
-        } else {
-            CKS_RW_USER_FUNCTIONS
-        };
-        let info = CK_SESSION_INFO {
-            slotID: SLOT_ID,
-            state,
-            flags,
-            ulDeviceError: 0,
-        };
+        let state =
+            if flags & CKF_RW_SESSION == 0 { CKS_RO_USER_FUNCTIONS } else { CKS_RW_USER_FUNCTIONS };
+        let info = CK_SESSION_INFO { slotID: SLOT_ID, state, flags, ulDeviceError: 0 };
         unsafe { *pInfo = info };
         Ok(())
     }
@@ -682,10 +671,7 @@ cryptoki_fn!(
             let max_objects = cmp::min(find_ctx.objects.len(), ulMaxObjectCount as usize);
             let output = unsafe { slice::from_raw_parts_mut(phObject, max_objects) };
             output.copy_from_slice(
-                &find_ctx
-                    .objects
-                    .drain(0..max_objects)
-                    .collect::<Vec<CK_OBJECT_HANDLE>>(),
+                &find_ctx.objects.drain(0..max_objects).collect::<Vec<CK_OBJECT_HANDLE>>(),
             );
             unsafe { *pulObjectCount = max_objects as CK_ULONG };
             Ok(())
@@ -1094,9 +1080,8 @@ pub mod tests {
 
     pub fn test_init() {
         if !INITIALIZED.load(std::sync::atomic::Ordering::SeqCst) {
-            let mut func_list: &mut CK_FUNCTION_LIST = &mut CK_FUNCTION_LIST {
-                ..Default::default()
-            };
+            let mut func_list: &mut CK_FUNCTION_LIST =
+                &mut CK_FUNCTION_LIST { ..Default::default() };
             unsafe { C_GetFunctionList((&mut func_list) as *mut _ as *mut _) };
         }
     }
@@ -1106,10 +1091,7 @@ pub mod tests {
     fn get_initialize() {
         test_init();
         assert_eq!(C_Initialize(ptr::null_mut()), CKR_OK);
-        assert_eq!(
-            C_Initialize(ptr::null_mut()),
-            CKR_CRYPTOKI_ALREADY_INITIALIZED
-        );
+        assert_eq!(C_Initialize(ptr::null_mut()), CKR_CRYPTOKI_ALREADY_INITIALIZED);
         assert_eq!(C_Finalize(ptr::null_mut()), CKR_OK);
         let mut args = CK_C_INITIALIZE_ARGS::default();
         assert_eq!(
@@ -1131,10 +1113,7 @@ pub mod tests {
         test_init();
         assert_eq!(C_Initialize(ptr::null_mut()), CKR_OK);
         // Expect CKR_ARGUMENTS_BAD if pReserved is not null.
-        assert_eq!(
-            C_Finalize(1 as *mut u32 as *mut std::ffi::c_void),
-            CKR_ARGUMENTS_BAD
-        );
+        assert_eq!(C_Finalize(1 as *mut u32 as *mut std::ffi::c_void), CKR_ARGUMENTS_BAD);
         assert_eq!(C_Finalize(ptr::null_mut()), CKR_OK);
         assert_eq!(C_Finalize(ptr::null_mut()), CKR_CRYPTOKI_NOT_INITIALIZED);
     }
@@ -1150,10 +1129,7 @@ pub mod tests {
         assert_eq!(unsafe { C_GetInfo(ptr::null_mut()) }, CKR_ARGUMENTS_BAD);
         // Expect CKR_CRYPTOKI_NOT_INITIALIZED if token is not initialized.
         assert_eq!(C_Finalize(ptr::null_mut()), CKR_OK);
-        assert_eq!(
-            unsafe { C_GetInfo(&mut info) },
-            CKR_CRYPTOKI_NOT_INITIALIZED
-        );
+        assert_eq!(unsafe { C_GetInfo(&mut info) }, CKR_CRYPTOKI_NOT_INITIALIZED);
     }
 
     #[test]
@@ -1162,15 +1138,9 @@ pub mod tests {
         test_init();
         let mut function_list = CK_FUNCTION_LIST::default();
         let mut function_list_pointer: *mut CK_FUNCTION_LIST = &mut function_list;
-        assert_eq!(
-            unsafe { C_GetFunctionList(&mut function_list_pointer) },
-            CKR_OK
-        );
+        assert_eq!(unsafe { C_GetFunctionList(&mut function_list_pointer) }, CKR_OK);
         // Expect CKR_ARGUMENTS_BAD if ppFunctionList is null.
-        assert_eq!(
-            unsafe { C_GetFunctionList(ptr::null_mut()) },
-            CKR_ARGUMENTS_BAD
-        );
+        assert_eq!(unsafe { C_GetFunctionList(ptr::null_mut()) }, CKR_ARGUMENTS_BAD);
     }
 
     #[test]
@@ -1179,10 +1149,7 @@ pub mod tests {
         test_init();
         assert_eq!(C_Initialize(ptr::null_mut()), CKR_OK);
         let mut count = 0;
-        assert_eq!(
-            unsafe { C_GetSlotList(CK_FALSE, std::ptr::null_mut(), &mut count) },
-            CKR_OK
-        );
+        assert_eq!(unsafe { C_GetSlotList(CK_FALSE, std::ptr::null_mut(), &mut count) }, CKR_OK);
         assert_eq!(count, 1);
         // Expect CKR_ARGUMENTS_BAD if pulCount is null.
         assert_eq!(
@@ -1213,21 +1180,12 @@ pub mod tests {
         let mut slot_info = CK_SLOT_INFO::default();
         assert_eq!(unsafe { C_GetSlotInfo(SLOT_ID, &mut slot_info) }, CKR_OK);
         // Expect CKR_ARGUMENTS_BAD if pInfo is null.
-        assert_eq!(
-            unsafe { C_GetSlotInfo(SLOT_ID, ptr::null_mut()) },
-            CKR_ARGUMENTS_BAD
-        );
+        assert_eq!(unsafe { C_GetSlotInfo(SLOT_ID, ptr::null_mut()) }, CKR_ARGUMENTS_BAD);
         // Expect CKR_SLOT_ID_INVALID if slotID references a nonexistent slot.
-        assert_eq!(
-            unsafe { C_GetSlotInfo(SLOT_ID + 1, ptr::null_mut()) },
-            CKR_SLOT_ID_INVALID
-        );
+        assert_eq!(unsafe { C_GetSlotInfo(SLOT_ID + 1, ptr::null_mut()) }, CKR_SLOT_ID_INVALID);
         // Expect CKR_CRYPTOKI_NOT_INITIALIZED if token is not initialized.
         assert_eq!(C_Finalize(ptr::null_mut()), CKR_OK);
-        assert_eq!(
-            unsafe { C_GetSlotInfo(SLOT_ID, &mut slot_info) },
-            CKR_CRYPTOKI_NOT_INITIALIZED
-        );
+        assert_eq!(unsafe { C_GetSlotInfo(SLOT_ID, &mut slot_info) }, CKR_CRYPTOKI_NOT_INITIALIZED);
     }
 
     #[test]
@@ -1235,20 +1193,11 @@ pub mod tests {
     fn get_token_info() {
         test_init();
         assert_eq!(C_Initialize(ptr::null_mut()), CKR_OK);
-        assert_eq!(
-            unsafe { C_GetTokenInfo(SLOT_ID, &mut CK_TOKEN_INFO::default()) },
-            CKR_OK
-        );
+        assert_eq!(unsafe { C_GetTokenInfo(SLOT_ID, &mut CK_TOKEN_INFO::default()) }, CKR_OK);
         // Expect CKR_SLOT_ID_INVALID if slotID references a nonexistent slot.
-        assert_eq!(
-            unsafe { C_GetTokenInfo(SLOT_ID + 1, ptr::null_mut()) },
-            CKR_SLOT_ID_INVALID
-        );
+        assert_eq!(unsafe { C_GetTokenInfo(SLOT_ID + 1, ptr::null_mut()) }, CKR_SLOT_ID_INVALID);
         // Expect CKR_ARGUMENTS_BAD if pInfo is null.
-        assert_eq!(
-            unsafe { C_GetSlotInfo(SLOT_ID, ptr::null_mut()) },
-            CKR_ARGUMENTS_BAD
-        );
+        assert_eq!(unsafe { C_GetSlotInfo(SLOT_ID, ptr::null_mut()) }, CKR_ARGUMENTS_BAD);
         // Expect CKR_CRYPTOKI_NOT_INITIALIZED if token is not initialized.
         assert_eq!(C_Finalize(ptr::null_mut()), CKR_OK);
         assert_eq!(
@@ -1263,10 +1212,7 @@ pub mod tests {
         test_init();
         assert_eq!(C_Initialize(ptr::null_mut()), CKR_OK);
         let mut count = 0;
-        assert_eq!(
-            unsafe { C_GetMechanismList(SLOT_ID, ptr::null_mut(), &mut count) },
-            CKR_OK
-        );
+        assert_eq!(unsafe { C_GetMechanismList(SLOT_ID, ptr::null_mut(), &mut count) }, CKR_OK);
         assert_ne!(count, 0);
         let mut mechanisms = Vec::<CK_MECHANISM_TYPE>::with_capacity(count as usize);
         assert_eq!(
@@ -1372,13 +1318,7 @@ pub mod tests {
         let mut handle = CK_INVALID_HANDLE;
         assert_eq!(
             unsafe {
-                C_OpenSession(
-                    SLOT_ID,
-                    CKF_SERIAL_SESSION,
-                    ptr::null_mut(),
-                    None,
-                    &mut handle,
-                )
+                C_OpenSession(SLOT_ID, CKF_SERIAL_SESSION, ptr::null_mut(), None, &mut handle)
             },
             CKR_OK
         );
@@ -1386,10 +1326,7 @@ pub mod tests {
         // Expect CKR_SESSION_HANDLE_INVALID if the session has already been closed.
         assert_eq!(C_CloseSession(handle), CKR_SESSION_HANDLE_INVALID);
         // Expect CKR_SESSION_HANDLE_INVALID if hSession is not a valid handle.
-        assert_eq!(
-            C_CloseSession(CK_INVALID_HANDLE),
-            CKR_SESSION_HANDLE_INVALID
-        );
+        assert_eq!(C_CloseSession(CK_INVALID_HANDLE), CKR_SESSION_HANDLE_INVALID);
         assert_eq!(C_Finalize(ptr::null_mut()), CKR_OK);
     }
 
@@ -1401,31 +1338,19 @@ pub mod tests {
         let mut handle = CK_INVALID_HANDLE;
         assert_eq!(
             unsafe {
-                C_OpenSession(
-                    SLOT_ID,
-                    CKF_SERIAL_SESSION,
-                    ptr::null_mut(),
-                    None,
-                    &mut handle,
-                )
+                C_OpenSession(SLOT_ID, CKF_SERIAL_SESSION, ptr::null_mut(), None, &mut handle)
             },
             CKR_OK
         );
         let mut session_info = CK_SESSION_INFO::default();
-        assert_eq!(
-            unsafe { C_GetSessionInfo(handle, &mut session_info) },
-            CKR_OK
-        );
+        assert_eq!(unsafe { C_GetSessionInfo(handle, &mut session_info) }, CKR_OK);
         // Expect CKR_SESSION_HANDLE_INVALID if hSession is not a valid handle.
         assert_eq!(
             unsafe { C_GetSessionInfo(CK_INVALID_HANDLE, &mut session_info) },
             CKR_SESSION_HANDLE_INVALID
         );
         // Expect CKR_ARGUMENTS_BAD if pInfo is null.
-        assert_eq!(
-            unsafe { C_GetSessionInfo(handle, ptr::null_mut()) },
-            CKR_ARGUMENTS_BAD
-        );
+        assert_eq!(unsafe { C_GetSessionInfo(handle, ptr::null_mut()) }, CKR_ARGUMENTS_BAD);
         assert_eq!(C_CloseSession(handle), CKR_OK);
         assert_eq!(C_Finalize(ptr::null_mut()), CKR_OK);
     }
@@ -1438,13 +1363,7 @@ pub mod tests {
         let mut session_h = CK_INVALID_HANDLE;
         assert_eq!(
             unsafe {
-                C_OpenSession(
-                    SLOT_ID,
-                    CKF_SERIAL_SESSION,
-                    ptr::null_mut(),
-                    None,
-                    &mut session_h,
-                )
+                C_OpenSession(SLOT_ID, CKF_SERIAL_SESSION, ptr::null_mut(), None, &mut session_h)
             },
             CKR_OK
         );
@@ -1476,13 +1395,7 @@ pub mod tests {
         let mut handle = CK_INVALID_HANDLE;
         assert_eq!(
             unsafe {
-                C_OpenSession(
-                    SLOT_ID,
-                    CKF_SERIAL_SESSION,
-                    ptr::null_mut(),
-                    None,
-                    &mut handle,
-                )
+                C_OpenSession(SLOT_ID, CKF_SERIAL_SESSION, ptr::null_mut(), None, &mut handle)
             },
             CKR_OK
         );
@@ -1506,13 +1419,7 @@ pub mod tests {
         let mut handle = CK_INVALID_HANDLE;
         assert_eq!(
             unsafe {
-                C_OpenSession(
-                    SLOT_ID,
-                    CKF_SERIAL_SESSION,
-                    ptr::null_mut(),
-                    None,
-                    &mut handle,
-                )
+                C_OpenSession(SLOT_ID, CKF_SERIAL_SESSION, ptr::null_mut(), None, &mut handle)
             },
             CKR_OK
         );
@@ -1521,16 +1428,10 @@ pub mod tests {
             pValue: CKO_PRIVATE_KEY as CK_VOID_PTR,
             ulValueLen: std::mem::size_of_val(&CKO_PRIVATE_KEY) as CK_ULONG,
         }];
-        assert_eq!(
-            unsafe { C_FindObjectsInit(handle, template.as_mut_ptr(), 0) },
-            CKR_OK
-        );
+        assert_eq!(unsafe { C_FindObjectsInit(handle, template.as_mut_ptr(), 0) }, CKR_OK);
         let mut objects = vec![CK_OBJECT_HANDLE::default()];
         let mut count = 0;
-        assert_eq!(
-            unsafe { C_FindObjects(handle, objects.as_mut_ptr(), 1, &mut count) },
-            CKR_OK
-        );
+        assert_eq!(unsafe { C_FindObjects(handle, objects.as_mut_ptr(), 1, &mut count) }, CKR_OK);
         assert_eq!(C_Finalize(ptr::null_mut()), CKR_OK);
         assert_eq!(
             unsafe { C_FindObjects(handle, ptr::null_mut(), 0, ptr::null_mut()) },
@@ -1546,13 +1447,7 @@ pub mod tests {
         let mut handle = CK_INVALID_HANDLE;
         assert_eq!(
             unsafe {
-                C_OpenSession(
-                    SLOT_ID,
-                    CKF_SERIAL_SESSION,
-                    ptr::null_mut(),
-                    None,
-                    &mut handle,
-                )
+                C_OpenSession(SLOT_ID, CKF_SERIAL_SESSION, ptr::null_mut(), None, &mut handle)
             },
             CKR_OK
         );
@@ -1574,13 +1469,7 @@ pub mod tests {
         let mut session_h = CK_INVALID_HANDLE;
         assert_eq!(
             unsafe {
-                C_OpenSession(
-                    SLOT_ID,
-                    CKF_SERIAL_SESSION,
-                    ptr::null_mut(),
-                    None,
-                    &mut session_h,
-                )
+                C_OpenSession(SLOT_ID, CKF_SERIAL_SESSION, ptr::null_mut(), None, &mut session_h)
             },
             CKR_OK
         );
@@ -1595,13 +1484,7 @@ pub mod tests {
         let mut session_h = CK_INVALID_HANDLE;
         assert_eq!(
             unsafe {
-                C_OpenSession(
-                    SLOT_ID,
-                    CKF_SERIAL_SESSION,
-                    ptr::null_mut(),
-                    None,
-                    &mut session_h,
-                )
+                C_OpenSession(SLOT_ID, CKF_SERIAL_SESSION, ptr::null_mut(), None, &mut session_h)
             },
             CKR_OK
         );

--- a/native-pkcs11/src/object_store.rs
+++ b/native-pkcs11/src/object_store.rs
@@ -214,9 +214,8 @@ mod tests {
 
         let label = &format!("objectstore test {}", random_label());
 
-        let key = backend()
-            .generate_key(native_pkcs11_traits::KeyAlgorithm::Rsa, Some(label))
-            .unwrap();
+        let key =
+            backend().generate_key(native_pkcs11_traits::KeyAlgorithm::Rsa, Some(label)).unwrap();
 
         let mut store = ObjectStore::default();
 

--- a/native-pkcs11/src/sessions.rs
+++ b/native-pkcs11/src/sessions.rs
@@ -58,9 +58,7 @@ impl Session {
             Some(sign_ctx) => sign_ctx,
             None => return Err(Error::OperationNotInitialized),
         };
-        let data = data
-            .or(sign_ctx.payload.as_deref())
-            .ok_or(Error::OperationNotInitialized)?;
+        let data = data.or(sign_ctx.payload.as_deref()).ok_or(Error::OperationNotInitialized)?;
         let signature = match sign_ctx.private_key.sign(&sign_ctx.algorithm, data) {
             Ok(sig) => sig,
             Err(e) => {
@@ -94,13 +92,7 @@ pub struct Session {
 
 pub fn create(flags: CK_FLAGS) -> CK_SESSION_HANDLE {
     let handle = NEXT_SESSION_HANDLE.fetch_add(1, Ordering::SeqCst);
-    SESSIONS.lock().unwrap().insert(
-        handle,
-        Session {
-            flags,
-            ..Default::default()
-        },
-    );
+    SESSIONS.lock().unwrap().insert(handle, Session { flags, ..Default::default() });
     handle
 }
 

--- a/native-pkcs11/src/utils.rs
+++ b/native-pkcs11/src/utils.rs
@@ -16,10 +16,7 @@ use std::io::Write;
 
 pub fn right_pad_string_to_array<const N: usize>(s: impl Into<String>) -> [u8; N] {
     let mut s: String = s.into();
-    let new_len = (0..=N)
-        .rev()
-        .find(|idx| s.is_char_boundary(*idx))
-        .unwrap_or(0);
+    let new_len = (0..=N).rev().find(|idx| s.is_char_boundary(*idx)).unwrap_or(0);
     s.truncate(new_len);
 
     let mut out = [b' '; N];

--- a/pkcs11-sys/Cargo.toml
+++ b/pkcs11-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs11-sys"
-version = "0.2.24"
+version = "0.2.25"
 description = "Generated bindings for pkcs11.h. Useful for building PKCS#11 modules in rust."
 authors.workspace = true
 edition.workspace = true

--- a/pkcs11-sys/build.rs
+++ b/pkcs11-sys/build.rs
@@ -38,100 +38,46 @@ mod generate {
         // https://github.com/rust-lang/rust-bindgen/issues/1594
         fn int_macro(&self, name: &str, _: i64) -> Option<callbacks::IntKind> {
             if ["CK_TRUE", "CK_FALSE"].contains(&name) {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_BBOOL",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_BBOOL", is_signed: false })
             } else if name.starts_with("CK_") {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_ULONG",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_ULONG", is_signed: false })
             } else if name.starts_with("CKA_") {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_ATTRIBUTE_TYPE",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_ATTRIBUTE_TYPE", is_signed: false })
             } else if name.starts_with("CKC_") {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_CERTIFICATE_TYPE",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_CERTIFICATE_TYPE", is_signed: false })
             } else if name.starts_with("CKD_") {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_EC_KDF_TYPE",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_EC_KDF_TYPE", is_signed: false })
             } else if name.starts_with("CKF_") {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_FLAGS",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_FLAGS", is_signed: false })
             } else if name.starts_with("CKG_MGF1_") {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_RSA_PKCS_MGF_TYPE",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_RSA_PKCS_MGF_TYPE", is_signed: false })
             } else if name.starts_with("CKG_") {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_GENERATOR_FUNCTION",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_GENERATOR_FUNCTION", is_signed: false })
             } else if name.starts_with("CKH_") {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_HW_FEATURE_TYPE",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_HW_FEATURE_TYPE", is_signed: false })
             } else if name.starts_with("CKK_") {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_KEY_TYPE",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_KEY_TYPE", is_signed: false })
             } else if name.starts_with("CKM_") {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_MECHANISM_TYPE",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_MECHANISM_TYPE", is_signed: false })
             } else if name.starts_with("CKN_") {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_NOTIFICATION",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_NOTIFICATION", is_signed: false })
             } else if name.starts_with("CKO_") {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_OBJECT_CLASS",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_OBJECT_CLASS", is_signed: false })
             } else if name.starts_with("CKP_") {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_PROFILE_ID",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_PROFILE_ID", is_signed: false })
             } else if name.starts_with("CKR_") {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_RV",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_RV", is_signed: false })
             } else if name.starts_with("CKS_") {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_STATE",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_STATE", is_signed: false })
             } else if name.starts_with("CKU_") {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_USER_TYPE",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_USER_TYPE", is_signed: false })
             } else if name.starts_with("CKZ_") {
                 Some(callbacks::IntKind::Custom {
                     name: "CK_RSA_PKCS_OAEP_SOURCE_TYPE",
                     is_signed: false,
                 })
             } else if name.starts_with("CRYPTOKI_VERSION_") {
-                Some(callbacks::IntKind::Custom {
-                    name: "CK_BYTE",
-                    is_signed: false,
-                })
+                Some(callbacks::IntKind::Custom { name: "CK_BYTE", is_signed: false })
             } else {
                 None
             }
@@ -173,9 +119,7 @@ mod generate {
 
         let bindings = bindings.generate().expect("failed to generate bindings");
 
-        bindings
-            .write_to_file(target_specific_output_path())
-            .expect("failed to write bindings");
+        bindings.write_to_file(target_specific_output_path()).expect("failed to write bindings");
     }
 }
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,6 +4,8 @@ format_strings = true
 group_imports = "StdExternalCrate"
 imports_granularity = "Crate"
 imports_layout = "HorizontalVertical"
-style_edition = "2021"
 unstable_features = true
+use_small_heuristics = "Max"
 wrap_comments = true
+
+ignore = ["pkcs11-sys/src/pkcs11_unix.rs", "pkcs11-sys/src/pkcs11_windows.rs"]


### PR DESCRIPTION
## 🤖 New release
* `native-pkcs11`: 0.2.24 -> 0.2.25 (✓ API compatible changes)
* `native-pkcs11-core`: 0.2.24 -> 0.2.25 (✓ API compatible changes)
* `native-pkcs11-traits`: 0.2.23 -> 0.2.24 (✓ API compatible changes)
* `pkcs11-sys`: 0.2.24 -> 0.2.25 (✓ API compatible changes)
* `native-pkcs11-keychain`: 0.2.24 -> 0.2.25 (✓ API compatible changes)
* `native-pkcs11-windows`: 0.2.24 -> 0.2.25 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).