### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "native-pkcs11"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "cached",
  "native-pkcs11-core",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-core"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "der",
  "native-pkcs11-keychain",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-keychain"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "core-foundation",
  "native-pkcs11-traits",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-traits"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "rand",
  "x509-cert",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-windows"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "native-pkcs11-traits",
  "windows",

--- a/native-pkcs11-core/CHANGELOG.md
+++ b/native-pkcs11-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.26](https://github.com/google/native-pkcs11/compare/native-pkcs11-core-v0.2.25...native-pkcs11-core-v0.2.26) - 2025-03-18
+
+### Other
+
+- Bump Rust edition to 2024, MSRV to 1.85 ([#381](https://github.com/google/native-pkcs11/pull/381))
+
 ## [0.2.25](https://github.com/google/native-pkcs11/compare/native-pkcs11-core-v0.2.24...native-pkcs11-core-v0.2.25) - 2025-02-21
 
 ### Other

--- a/native-pkcs11-core/Cargo.toml
+++ b/native-pkcs11-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-core"
-version = "0.2.25"
+version = "0.2.26"
 description = "Shared cross-platform PKCS#11 module logic for native-pkcs11."
 authors.workspace = true
 edition.workspace = true
@@ -10,7 +10,7 @@ license.workspace = true
 
 [dependencies]
 der = "0.7.9"
-native-pkcs11-traits = { version = "0.2.24", path = "../native-pkcs11-traits" }
+native-pkcs11-traits = { version = "0.2.25", path = "../native-pkcs11-traits" }
 pkcs1 = { version = "0.7.5", default-features = false }
 pkcs11-sys = { version = "0.2.25", path = "../pkcs11-sys" }
 pkcs8 = "0.10.2"
@@ -23,7 +23,7 @@ tracing = "0.1.41"
 serial_test = { version = "3.2.0", default-features = false }
 
 [target.'cfg(target_os="macos")'.dependencies]
-native-pkcs11-keychain = { version = "0.2.25", path = "../native-pkcs11-keychain" }
+native-pkcs11-keychain = { version = "0.2.26", path = "../native-pkcs11-keychain" }
 
 [target.'cfg(target_os="windows")'.dependencies]
-native-pkcs11-windows = { version = "0.2.25", path = "../native-pkcs11-windows" }
+native-pkcs11-windows = { version = "0.2.26", path = "../native-pkcs11-windows" }

--- a/native-pkcs11-keychain/CHANGELOG.md
+++ b/native-pkcs11-keychain/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.26](https://github.com/google/native-pkcs11/compare/native-pkcs11-keychain-v0.2.25...native-pkcs11-keychain-v0.2.26) - 2025-03-18
+
+### Other
+
+- Bump Rust edition to 2024, MSRV to 1.85 ([#381](https://github.com/google/native-pkcs11/pull/381))
+
 ## [0.2.25](https://github.com/google/native-pkcs11/compare/native-pkcs11-keychain-v0.2.24...native-pkcs11-keychain-v0.2.25) - 2025-02-21
 
 ### Other

--- a/native-pkcs11-keychain/Cargo.toml
+++ b/native-pkcs11-keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-keychain"
-version = "0.2.25"
+version = "0.2.26"
 description = "native-pkcs11 backend for macos keychain."
 authors.workspace = true
 edition.workspace = true
@@ -9,7 +9,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-native-pkcs11-traits = { version = "0.2.24", path = "../native-pkcs11-traits" }
+native-pkcs11-traits = { version = "0.2.25", path = "../native-pkcs11-traits" }
 thiserror = "2"
 tracing = "0.1.41"
 tracing-error = { version = "0.2.1", default-features = false }

--- a/native-pkcs11-traits/CHANGELOG.md
+++ b/native-pkcs11-traits/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.25](https://github.com/google/native-pkcs11/compare/native-pkcs11-traits-v0.2.24...native-pkcs11-traits-v0.2.25) - 2025-03-18
+
+### Other
+
+- Bump Rust edition to 2024, MSRV to 1.85 ([#381](https://github.com/google/native-pkcs11/pull/381))
+
 ## [0.2.24](https://github.com/google/native-pkcs11/compare/native-pkcs11-traits-v0.2.23...native-pkcs11-traits-v0.2.24) - 2025-02-21
 
 ### Other

--- a/native-pkcs11-traits/Cargo.toml
+++ b/native-pkcs11-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-traits"
-version = "0.2.24"
+version = "0.2.25"
 description = "Traits for implementing and interactive with native-pkcs11 module backends."
 authors.workspace = true
 edition.workspace = true

--- a/native-pkcs11-windows/CHANGELOG.md
+++ b/native-pkcs11-windows/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.26](https://github.com/google/native-pkcs11/compare/native-pkcs11-windows-v0.2.25...native-pkcs11-windows-v0.2.26) - 2025-03-18
+
+### Other
+
+- Bump the cargo group with 3 updates ([#407](https://github.com/google/native-pkcs11/pull/407))
+- Bump Rust edition to 2024, MSRV to 1.85 ([#381](https://github.com/google/native-pkcs11/pull/381))
+
 ## [0.2.25](https://github.com/google/native-pkcs11/compare/native-pkcs11-windows-v0.2.24...native-pkcs11-windows-v0.2.25) - 2025-02-21
 
 ### Other

--- a/native-pkcs11-windows/Cargo.toml
+++ b/native-pkcs11-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-windows"
-version = "0.2.25"
+version = "0.2.26"
 description = "[wip] native-pkcs11 backend for windows."
 authors.workspace = true
 edition.workspace = true
@@ -9,7 +9,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-native-pkcs11-traits = { version = "0.2.24", path = "../native-pkcs11-traits" }
+native-pkcs11-traits = { version = "0.2.25", path = "../native-pkcs11-traits" }
 
 [target.'cfg(target_os="windows")'.dependencies.windows]
 version = "0.60.0"

--- a/native-pkcs11/CHANGELOG.md
+++ b/native-pkcs11/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.26](https://github.com/google/native-pkcs11/compare/native-pkcs11-v0.2.25...native-pkcs11-v0.2.26) - 2025-03-18
+
+### Other
+
+- Return all certs, not just those with private keys. ([#411](https://github.com/google/native-pkcs11/pull/411))
+- bug fix: use public keys in find_with_backend_all_public_keys. ([#410](https://github.com/google/native-pkcs11/pull/410))
+- Bump the cargo group with 3 updates ([#407](https://github.com/google/native-pkcs11/pull/407))
+- Bump Rust edition to 2024, MSRV to 1.85 ([#381](https://github.com/google/native-pkcs11/pull/381))
+
 ## [0.2.25](https://github.com/google/native-pkcs11/compare/native-pkcs11-v0.2.24...native-pkcs11-v0.2.25) - 2025-02-21
 
 ### Other

--- a/native-pkcs11/Cargo.toml
+++ b/native-pkcs11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11"
-version = "0.2.25"
+version = "0.2.26"
 description = "Cross-platform PKCS#11 module written in rust. Can be extended with custom credential backends."
 authors.workspace = true
 edition.workspace = true
@@ -13,8 +13,8 @@ custom-function-list = []
 
 [dependencies]
 cached = { version = "~0.55", default-features = false }
-native-pkcs11-core = { version = "^0.2.25", path = "../native-pkcs11-core" }
-native-pkcs11-traits = { version = "0.2.24", path = "../native-pkcs11-traits" }
+native-pkcs11-core = { version = "^0.2.26", path = "../native-pkcs11-core" }
+native-pkcs11-traits = { version = "0.2.25", path = "../native-pkcs11-traits" }
 pkcs11-sys = { version = "0.2.25", path = "../pkcs11-sys" }
 thiserror = "2"
 tracing = "0.1.41"
@@ -33,7 +33,7 @@ tracing-subscriber = { version = "0.3.19", default-features = false, features = 
 ] }
 
 [target.'cfg(target_os="macos")'.dependencies]
-native-pkcs11-keychain = { version = "0.2.25", path = "../native-pkcs11-keychain" }
+native-pkcs11-keychain = { version = "0.2.26", path = "../native-pkcs11-keychain" }
 
 [target.'cfg(target_os="windows")'.dependencies]
-native-pkcs11-windows = { version = "0.2.25", path = "../native-pkcs11-windows" }
+native-pkcs11-windows = { version = "0.2.26", path = "../native-pkcs11-windows" }


### PR DESCRIPTION



## 🤖 New release

* `native-pkcs11-traits`: 0.2.24 -> 0.2.25 (✓ API compatible changes)
* `native-pkcs11-keychain`: 0.2.25 -> 0.2.26 (✓ API compatible changes)
* `native-pkcs11-windows`: 0.2.25 -> 0.2.26 (✓ API compatible changes)
* `native-pkcs11-core`: 0.2.25 -> 0.2.26 (✓ API compatible changes)
* `native-pkcs11`: 0.2.25 -> 0.2.26 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `native-pkcs11-traits`

<blockquote>

## [0.2.25](https://github.com/google/native-pkcs11/compare/native-pkcs11-traits-v0.2.24...native-pkcs11-traits-v0.2.25) - 2025-03-18

### Other

- Bump Rust edition to 2024, MSRV to 1.85 ([#381](https://github.com/google/native-pkcs11/pull/381))
</blockquote>

## `native-pkcs11-keychain`

<blockquote>

## [0.2.26](https://github.com/google/native-pkcs11/compare/native-pkcs11-keychain-v0.2.25...native-pkcs11-keychain-v0.2.26) - 2025-03-18

### Other

- Bump Rust edition to 2024, MSRV to 1.85 ([#381](https://github.com/google/native-pkcs11/pull/381))
</blockquote>

## `native-pkcs11-windows`

<blockquote>

## [0.2.26](https://github.com/google/native-pkcs11/compare/native-pkcs11-windows-v0.2.25...native-pkcs11-windows-v0.2.26) - 2025-03-18

### Other

- Bump the cargo group with 3 updates ([#407](https://github.com/google/native-pkcs11/pull/407))
- Bump Rust edition to 2024, MSRV to 1.85 ([#381](https://github.com/google/native-pkcs11/pull/381))
</blockquote>

## `native-pkcs11-core`

<blockquote>

## [0.2.26](https://github.com/google/native-pkcs11/compare/native-pkcs11-core-v0.2.25...native-pkcs11-core-v0.2.26) - 2025-03-18

### Other

- Bump Rust edition to 2024, MSRV to 1.85 ([#381](https://github.com/google/native-pkcs11/pull/381))
</blockquote>

## `native-pkcs11`

<blockquote>

## [0.2.26](https://github.com/google/native-pkcs11/compare/native-pkcs11-v0.2.25...native-pkcs11-v0.2.26) - 2025-03-18

### Other

- Return all certs, not just those with private keys. ([#411](https://github.com/google/native-pkcs11/pull/411))
- bug fix: use public keys in find_with_backend_all_public_keys. ([#410](https://github.com/google/native-pkcs11/pull/410))
- Bump the cargo group with 3 updates ([#407](https://github.com/google/native-pkcs11/pull/407))
- Bump Rust edition to 2024, MSRV to 1.85 ([#381](https://github.com/google/native-pkcs11/pull/381))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).