### PR TITLE
bug fix: use public keys in find_with_backend_all_public_keys.

### DIFF
--- a/native-pkcs11/src/object_store.rs
+++ b/native-pkcs11/src/object_store.rs
@@ -167,8 +167,8 @@ impl ObjectStore {
     }
 
     fn find_with_backend_all_public_keys(&mut self) -> Result<()> {
-        for private_key in backend().find_all_private_keys()? {
-            self.insert(Object::PrivateKey(private_key));
+        for public_key in backend().find_all_public_keys()? {
+            self.insert(Object::PublicKey(public_key));
         }
         Ok(())
     }


### PR DESCRIPTION
find_with_backend_all_public_keys() was actually getting all *private* keys.

This PR fixes this, and fetches *public* keys.