### PR TITLE
Return all certs, not just those with private keys.

### DIFF
--- a/native-pkcs11/src/object_store.rs
+++ b/native-pkcs11/src/object_store.rs
@@ -153,14 +153,6 @@ impl ObjectStore {
 
     fn find_with_backend_all_certificates(&mut self) -> Result<()> {
         for cert in backend().find_all_certificates()? {
-            let private_key = backend().find_private_key(KeySearchOptions::PublicKeyHash(
-                cert.public_key().public_key_hash().as_slice().try_into()?,
-            ))?;
-            //  Check if certificate has an associated PrivateKey.
-            match private_key {
-                Some(key) => key,
-                None => continue,
-            };
             self.insert(Object::Certificate(cert.into()));
         }
         Ok(())


### PR DESCRIPTION
This is crucial in allowing this module to return intermediate certs (which clearly will not have private keys), not just leaf certs.