### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "native-pkcs11"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "cached",
  "native-pkcs11-core",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-core"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "der",
  "native-pkcs11-keychain",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "native-pkcs11-windows"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "native-pkcs11-traits",
  "windows",
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "pkcs11-sys"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "bindgen",
 ]

--- a/native-pkcs11-core/CHANGELOG.md
+++ b/native-pkcs11-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.28](https://github.com/google/native-pkcs11/compare/native-pkcs11-core-v0.2.27...native-pkcs11-core-v0.2.28) - 2025-06-16
+
+### Other
+
+- updated the following local packages: pkcs11-sys, native-pkcs11-windows
+
 ## [0.2.26](https://github.com/google/native-pkcs11/compare/native-pkcs11-core-v0.2.25...native-pkcs11-core-v0.2.26) - 2025-03-18
 
 ### Other

--- a/native-pkcs11-core/Cargo.toml
+++ b/native-pkcs11-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-core"
-version = "0.2.27"
+version = "0.2.28"
 description = "Shared cross-platform PKCS#11 module logic for native-pkcs11."
 authors.workspace = true
 edition.workspace = true
@@ -12,7 +12,7 @@ license.workspace = true
 der = "0.7.10"
 native-pkcs11-traits = { version = "0.2.25", path = "../native-pkcs11-traits" }
 pkcs1 = { version = "0.7.5", default-features = false }
-pkcs11-sys = { version = "0.2.25", path = "../pkcs11-sys" }
+pkcs11-sys = { version = "0.2.26", path = "../pkcs11-sys" }
 pkcs8 = "0.10.2"
 strum = "0.27"
 strum_macros = "0.27"
@@ -26,4 +26,4 @@ serial_test = { version = "3.2.0", default-features = false }
 native-pkcs11-keychain = { version = "0.2.26", path = "../native-pkcs11-keychain" }
 
 [target.'cfg(target_os="windows")'.dependencies]
-native-pkcs11-windows = { version = "0.2.26", path = "../native-pkcs11-windows" }
+native-pkcs11-windows = { version = "0.2.28", path = "../native-pkcs11-windows" }

--- a/native-pkcs11-windows/CHANGELOG.md
+++ b/native-pkcs11-windows/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.28](https://github.com/google/native-pkcs11/compare/native-pkcs11-windows-v0.2.27...native-pkcs11-windows-v0.2.28) - 2025-06-16
+
+### Other
+
+- Bump the cargo group across 1 directory with 2 updates ([#431](https://github.com/google/native-pkcs11/pull/431))
+- Fix new Clippy lint ([#427](https://github.com/google/native-pkcs11/pull/427))
+
 ## [0.2.26](https://github.com/google/native-pkcs11/compare/native-pkcs11-windows-v0.2.25...native-pkcs11-windows-v0.2.26) - 2025-03-18
 
 ### Other

--- a/native-pkcs11-windows/Cargo.toml
+++ b/native-pkcs11-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11-windows"
-version = "0.2.27"
+version = "0.2.28"
 description = "[wip] native-pkcs11 backend for windows."
 authors.workspace = true
 edition.workspace = true

--- a/native-pkcs11/CHANGELOG.md
+++ b/native-pkcs11/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.28](https://github.com/google/native-pkcs11/compare/native-pkcs11-v0.2.27...native-pkcs11-v0.2.28) - 2025-06-16
+
+### Other
+
+- updated the following local packages: pkcs11-sys, native-pkcs11-windows, native-pkcs11-core
+
 ## [0.2.26](https://github.com/google/native-pkcs11/compare/native-pkcs11-v0.2.25...native-pkcs11-v0.2.26) - 2025-03-18
 
 ### Other

--- a/native-pkcs11/Cargo.toml
+++ b/native-pkcs11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-pkcs11"
-version = "0.2.27"
+version = "0.2.28"
 description = "Cross-platform PKCS#11 module written in rust. Can be extended with custom credential backends."
 authors.workspace = true
 edition.workspace = true
@@ -13,9 +13,9 @@ custom-function-list = []
 
 [dependencies]
 cached = { version = "~0.55", default-features = false }
-native-pkcs11-core = { version = "^0.2.26", path = "../native-pkcs11-core" }
+native-pkcs11-core = { version = "^0.2.28", path = "../native-pkcs11-core" }
 native-pkcs11-traits = { version = "0.2.25", path = "../native-pkcs11-traits" }
-pkcs11-sys = { version = "0.2.25", path = "../pkcs11-sys" }
+pkcs11-sys = { version = "0.2.26", path = "../pkcs11-sys" }
 thiserror = "2"
 tracing = "0.1.41"
 tracing-error = "0.2.1"
@@ -36,4 +36,4 @@ tracing-subscriber = { version = "0.3.19", default-features = false, features = 
 native-pkcs11-keychain = { version = "0.2.26", path = "../native-pkcs11-keychain" }
 
 [target.'cfg(target_os="windows")'.dependencies]
-native-pkcs11-windows = { version = "0.2.26", path = "../native-pkcs11-windows" }
+native-pkcs11-windows = { version = "0.2.28", path = "../native-pkcs11-windows" }

--- a/pkcs11-sys/CHANGELOG.md
+++ b/pkcs11-sys/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.26](https://github.com/google/native-pkcs11/compare/pkcs11-sys-v0.2.25...pkcs11-sys-v0.2.26) - 2025-06-16
+
+### Other
+
+- Bump the cargo group across 1 directory with 2 updates ([#431](https://github.com/google/native-pkcs11/pull/431))
+
 ## [0.2.25](https://github.com/google/native-pkcs11/compare/pkcs11-sys-v0.2.24...pkcs11-sys-v0.2.25) - 2025-02-21
 
 ### Other

--- a/pkcs11-sys/Cargo.toml
+++ b/pkcs11-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkcs11-sys"
-version = "0.2.25"
+version = "0.2.26"
 description = "Generated bindings for pkcs11.h. Useful for building PKCS#11 modules in rust."
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `pkcs11-sys`: 0.2.25 -> 0.2.26 (✓ API compatible changes)
* `native-pkcs11-windows`: 0.2.27 -> 0.2.28 (✓ API compatible changes)
* `native-pkcs11-core`: 0.2.27 -> 0.2.28
* `native-pkcs11`: 0.2.27 -> 0.2.28

<details><summary><i><b>Changelog</b></i></summary><p>

## `pkcs11-sys`

<blockquote>

## [0.2.26](https://github.com/google/native-pkcs11/compare/pkcs11-sys-v0.2.25...pkcs11-sys-v0.2.26) - 2025-06-16

### Other

- Bump the cargo group across 1 directory with 2 updates ([#431](https://github.com/google/native-pkcs11/pull/431))
</blockquote>

## `native-pkcs11-windows`

<blockquote>

## [0.2.28](https://github.com/google/native-pkcs11/compare/native-pkcs11-windows-v0.2.27...native-pkcs11-windows-v0.2.28) - 2025-06-16

### Other

- Bump the cargo group across 1 directory with 2 updates ([#431](https://github.com/google/native-pkcs11/pull/431))
- Fix new Clippy lint ([#427](https://github.com/google/native-pkcs11/pull/427))
</blockquote>

## `native-pkcs11-core`

<blockquote>

## [0.2.28](https://github.com/google/native-pkcs11/compare/native-pkcs11-core-v0.2.27...native-pkcs11-core-v0.2.28) - 2025-06-16

### Other

- updated the following local packages: pkcs11-sys, native-pkcs11-windows
</blockquote>

## `native-pkcs11`

<blockquote>

## [0.2.28](https://github.com/google/native-pkcs11/compare/native-pkcs11-v0.2.27...native-pkcs11-v0.2.28) - 2025-06-16

### Other

- updated the following local packages: pkcs11-sys, native-pkcs11-windows, native-pkcs11-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).